### PR TITLE
Add Japanese functional spec and clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-~# WBS  Whiteboard Signage System
+# WBS  Whiteboard Signage System
 
 > **Nuxt3 + Prisma + Socket.IO + ConoHaVPS**
 > Collaborative scheduling & signage platform replacing physical whiteboards.
@@ -139,4 +139,4 @@ See `.env.sample` for full list.
 ## License
 
 MIT  2025watchout
-~
+

--- a/docs/functional_spec.ja.md
+++ b/docs/functional_spec.ja.md
@@ -1,0 +1,21 @@
+# 機能仕様書
+
+このドキュメントは README に記載された要件をまとめたものです。
+
+- **リアルタイム同期**: WebSocket(Socket.IO) を用いたルーム単位の同期。P95 1 秒未満を目標とする。
+- **Google カレンダー連携**: インクリメンタル同期と Webhook を利用した双方向同期。
+- **オフラインキオスク対応**: PWA + IndexedDB により 24 時間キャッシュし、WiFi がなくても表示を維持。
+- **多言語インタフェース**: `ja`, `en`, `vi`, `zhHans`, `fil`, `ne`, `ptBR` をサポート。
+- **RBAC**: `ADMIN`, `MEMBER`, `DEVICE` のロール。OAuth2 と MagicLink 認証を採用。
+- **IaC**: ConoHa プロバイダの Terraform によりコマンド一つで VPS とロードバランサを構築。
+- **CI/CD**: GitHub Actions が Docker イメージをビルドし、SSH でデプロイ。Watchtower によりコンテナ更新を管理。
+- **システム構成**: ブラウザやキオスク端末は HTTPS/WSS 経由で Nginx のロードバランサへ接続。複数の Nuxt インスタンスが Prisma 経由で PostgreSQL と通信し、WAL はオブジェクトストレージへ保存。
+- **開発手順**: リポジトリをクローンして依存をインストールし、`.env.sample` を `.env.local` にコピーして Google 認証情報を設定。`pnpm dev` で開発スタックを起動。必要なら Prisma Studio を開く。
+- **前提条件**: Node 20、pnpm、Docker 24(Postgres/Redis 用)、Terraform 1.7(インフラ構築時)。
+- **プロジェクトスクリプト**: `pnpm dev`、`pnpm build`、`pnpm lint`、`pnpm test`、`pnpm e2e`、`pnpm prisma:migrate`、`pnpm prisma:generate`、`pnpm prisma:studio`。
+- **Docker(本番同等ローカル)**: `docker compose up --build` でマルチサービススタックを構築・起動。Nuxt は http://localhost:3000、Postgres は localhost:5432 に展開。
+- **デプロイ手順**: `infra` ディレクトリで Terraform を実行し、`scripts/bootstrap_vps.sh` で VPS を初期化。その後 CI でコンテナイメージをビルドしてプッシュ。
+- **環境変数**: 必須は `DATABASE_URL`、`GOOGLE_CLIENT_ID`、`GOOGLE_CLIENT_SECRET`、`JWT_SECRET`、`APP_BASE_URL`。詳細は `.env.sample` を参照。
+- **品質ゲート**: Vitest による単体テスト(90% カバレッジ)、Playwright による E2E、200 rps・15 分間の k6 負荷テスト、Lighthouse PWA スコア 80。
+- **貢献ルール**: フィーチャーブランチを作成して Conventional Commits で PR。`pnpm lint && pnpm test` が必須。`@watchout/core` メンバーによるレビュー後、マージで自動デプロイ。
+- **ライセンス**: MIT (© 2025 watchout)。

--- a/docs/functional_spec.md
+++ b/docs/functional_spec.md
@@ -1,0 +1,22 @@
+# Functional Specification
+
+This document compiles requirements mentioned in the project's README.
+
+- **Realtime Synchronization**: WebSocket (Socket.IO) based room synchronization with a target latency of under one second (P95).
+- **Google Calendar Sync**: Bidirectional integration using incremental sync and webhooks.
+- **Offline Kiosk Support**: PWA with IndexedDB caching for 24 hours to keep screens functional without WiFi.
+- **Multilanguage Interface**: Supports `ja`, `en`, `vi`, `zhHans`, `fil`, `ne`, `ptBR` languages.
+- **Role Based Access Control**: `ADMIN`, `MEMBER`, and `DEVICE` roles with OAuth2 and MagicLink authentication.
+- **Infrastructure as Code**: Terraform (ConoHa provider) allows one command VPS and load balancer deployment.
+- **CI/CD**: GitHub Actions build Docker images and deploy via SSH with Watchtower handling container updates.
+- **System Architecture**: Browsers and kiosk devices communicate over HTTPS/WSS through an Nginx load balancer to multiple Nuxt application instances. Each instance connects to PostgreSQL via Prisma. PostgreSQL writes ahead logs are stored in object storage.
+- **Development Steps**: clone the repository, install dependencies, copy `.env.sample` to `.env.local` with Google credentials, start the development stack with `pnpm dev`, and optionally launch Prisma Studio.
+- **Prerequisites**: Node 20, pnpm, Docker 24 (for Postgres/Redis), Terraform 1.7 (for provisioning infrastructure).
+- **Project Scripts**: `pnpm dev`, `pnpm build`, `pnpm lint`, `pnpm test`, `pnpm e2e`, `pnpm prisma:migrate`, `pnpm prisma:generate`, `pnpm prisma:studio`.
+- **Docker (Prod‑like Local)**: `docker compose up --build` builds and runs the multiservice stack; Nuxt available at http://localhost:3000, Postgres at localhost:5432.
+- **Deployment Workflow**: run Terraform in `infra` directory, bootstrap VPS with `scripts/bootstrap_vps.sh`, then build and push container images via CI.
+- **Environment Variables**: at minimum `DATABASE_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `JWT_SECRET`, `APP_BASE_URL`. See `.env.sample` for full list.
+- **Quality Gates**: Vitest unit tests targeting 90% coverage, Playwright E2E tests on Chrome and Android WebView, k6 load test at 200 rps for 15 minutes, Lighthouse PWA score of 80.
+- **Contribution Requirements**: create feature branch and PR using Conventional Commits; `pnpm lint && pnpm test` must pass; review required by a member of `@watchout/core`; merges trigger automatic staging deployment via GitHub Actions.
+- **License**: MIT (© 2025 watchout).
+

--- a/docs/ui_flow.mmd
+++ b/docs/ui_flow.mmd
@@ -1,0 +1,8 @@
+graph TD
+  A(Login) --> B{Role}
+  B -->|ADMIN| C[Dashboard]
+  B -->|MEMBER| D[Schedule Board]
+  B -->|DEVICE| E[Signage Screen]
+  C --> D
+  D --> E
+  E -->|Offline\nPWA| F[Cached Display]


### PR DESCRIPTION
## Summary
- fix stray tildes in `README.md`
- use the longer functional spec extracted from README
- add a Japanese translation of the functional spec

## Testing
- `git status --short`
