### PR TITLE
Add Japanese functional spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ See `.env.sample` for full list.
 
 ---
 
+## Documentation
+
+For a full list of functional requirements, see:
+
+- [Functional Specification (EN)](docs/functional_spec.md)
+- [機能仕様書 (JA)](docs/functional_spec.ja.md)
+
+---
+
 ## Quality Gates
 
 * **Unit**  Vitest (90% line coverage target)


### PR DESCRIPTION
## Summary
- add documentation section to README referencing English and Japanese functional specs

## Testing
- `git status --short`