### PR TITLE
Add socket event payload docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ For a full list of functional requirements, see:
 
 - [Functional Specification (EN)](docs/functional_spec.md)
 - [機能仕様書 (JA)](docs/functional_spec.ja.md)
+- [Realtime Socket Events (EN)](docs/socket_events.md)
+- [リアルタイムイベント仕様 (JA)](docs/socket_events.ja.md)
 
 ---
 

--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -11,6 +11,8 @@ The repository is organized as follows:
 │   ├── devops.ja.md
 │   ├── functional_spec.md
 │   ├── functional_spec.ja.md
+│   ├── socket_events.md
+│   ├── socket_events.ja.md
 │   └── ui_flow.mmd
 └── prisma/             # Prisma ORM schemas
     ├── schema.prisma

--- a/docs/socket_events.ja.md
+++ b/docs/socket_events.ja.md
@@ -1,0 +1,13 @@
+# リアルタイムソケットイベント
+
+*English version: [socket_events.md](./socket_events.md)*
+
+このドキュメントでは、Socket.IO 接続でやり取りされるイベント名と JSON 形式のペイロードを示します。接続時の `roomId` に基づき、すべてのイベントはルーム単位で処理されます。
+
+| イベント名 | 方向 | ペイロード |
+|-------------|------|-----------|
+| `room:join` | サーバー → ルーム内全クライアント | `{ "userId": string }` |
+| `room:leave` | サーバー → ルーム内全クライアント | `{ "userId": string }` |
+| `room:update` | クライアント → サーバー → ブロードキャスト | `{ "schedule": Schedule }` |
+
+`Schedule` の構造は [`openapi.yaml`](../openapi.yaml) の `components/schemas/Schedule` を参照してください。

--- a/docs/socket_events.md
+++ b/docs/socket_events.md
@@ -1,0 +1,13 @@
+# Realtime Socket Events
+
+*Japanese version: [socket_events.ja.md](./socket_events.ja.md)*
+
+This document describes the event names and JSON payloads exchanged over the Socket.IO connection. All events are scoped to a room identified by the `roomId` passed during the connection handshake.
+
+| Event name | Direction | Payload |
+|------------|-----------|--------|
+| `room:join` | server -> all clients in room | `{ "userId": string }` |
+| `room:leave` | server -> all clients in room | `{ "userId": string }` |
+| `room:update` | client -> server -> broadcast | `{ "schedule": Schedule }` |
+
+`Schedule` follows the structure defined in [`openapi.yaml`](../openapi.yaml) under `components/schemas/Schedule`.


### PR DESCRIPTION
## Summary
- document socket event payloads in English and Japanese
- reference new docs from README
- list new docs in dir_structure

## Testing
- `npm test` *(fails: Missing script)*