### PR TITLE
fix(deploy): Dockerfile ビルド順序修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+# prisma schema + nuxt config を先にコピー
+# (npm ci の postinstall で nuxt prepare && prisma generate が走るため)
 COPY package.json package-lock.json ./
-RUN npm ci
-
 COPY prisma ./prisma
-RUN npx prisma generate
+COPY nuxt.config.ts tsconfig.json ./
+COPY app.vue ./
+
+RUN npm ci
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- `npm ci` の postinstall (`nuxt prepare && prisma generate`) が失敗していた問題を修正
- prisma schema, nuxt.config.ts, app.vue を `npm ci` 前にCOPYするよう順序変更

## 原因
Deploy workflow (#38) で Docker build が失敗: `prisma/schema.prisma: file not found`
`npm ci` → postinstall → `prisma generate` → schema がまだCOPYされていない

## Test plan
- [ ] CI通過 + Deploy workflow でDocker imageビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)