### PR TITLE
fix(deploy): Docker ビルドからテストファイルを除外

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@ dist
 *.md
 !README.md
 tests
+**/*.test.ts
+**/*.spec.ts
 進捗報告
 docs/knowledge
 .claude


### PR DESCRIPTION
## Summary
- `.dockerignore` に `**/*.test.ts` と `**/*.spec.ts` を追加
- `server/api/` 内のテストファイルが Docker ビルドに含まれ、`tests/helpers` の型解決に失敗していた問題を修正

## Test plan
- [ ] Deploy workflow で Docker image ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)