### PR TITLE
test(e2e): Playwright E2Eテスト基盤構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ tests/visual/diff/
 # Backups (contains production DB dumps)
 /backups/
 
+# Playwright
+playwright-report/
+tests/e2e/artifacts/
+
 # Progress reports (local only)
 進捗報告/

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@nuxt/devtools": "^1.0.0",
+        "@playwright/test": "^1.58.2",
         "@types/bcrypt": "^6.0.0",
         "@types/node": "^22.0.0",
         "@types/nodemailer": "^7.0.10",
@@ -3450,6 +3451,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -11239,6 +11256,53 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postal-mime": {
       "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@nuxt/devtools": "^1.0.0",
+    "@playwright/test": "^1.58.2",
     "@types/bcrypt": "^6.0.0",
     "@types/node": "^22.0.0",
     "@types/nodemailer": "^7.0.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['list'],
+  ],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:6001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // ローカル開発サーバー（CI ではすでに起動済み想定）
+  webServer: process.env.CI ? undefined : {
+    command: 'npm run dev',
+    url: 'http://localhost:6001',
+    reuseExistingServer: true,
+    timeout: 60000,
+  },
+  // 出力先
+  outputDir: 'tests/e2e/artifacts',
+})

--- a/tests/e2e/api.spec.ts
+++ b/tests/e2e/api.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * E2E: API エンドポイントテスト
+ *
+ * テスト対象:
+ * - ヘルスチェック
+ * - 認証API
+ * - スケジュールAPI（認証なしでの403）
+ * - 管理者API（権限チェック）
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('API: ヘルスチェック', () => {
+  test('GET /api/health が 200 を返す', async ({ request }) => {
+    const response = await request.get('/api/health')
+    expect(response.status()).toBe(200)
+
+    const data = await response.json()
+    expect(['healthy', 'degraded']).toContain(data.status)
+    expect(data).toHaveProperty('timestamp')
+    expect(data).toHaveProperty('checks')
+  })
+})
+
+test.describe('API: 認証', () => {
+  test('POST /api/auth/login で不正な認証情報は 401', async ({ request }) => {
+    const response = await request.post('/api/auth/login', {
+      data: {
+        email: 'nonexistent@example.com',
+        password: 'wrongpassword',
+      },
+    })
+
+    // 401 or 400 (not found user)
+    expect([400, 401]).toContain(response.status())
+  })
+
+  test('POST /api/auth/login でメールなしは 400', async ({ request }) => {
+    const response = await request.post('/api/auth/login', {
+      data: {
+        password: 'somepassword',
+      },
+    })
+
+    expect(response.status()).toBe(400)
+  })
+
+  test('GET /api/auth/me で未認証は認証失敗を返す', async ({ request }) => {
+    const response = await request.get('/api/auth/me')
+
+    // 認証なしでもエラーにならず isAuthenticated: false を返す
+    const data = await response.json()
+    expect(data.isAuthenticated).toBe(false)
+  })
+})
+
+test.describe('API: スケジュール（未認証）', () => {
+  test('GET /api/schedules で未認証はエラーを返す', async ({ request }) => {
+    const response = await request.get('/api/schedules')
+    // GET /api/schedules のリストエンドポイントが存在しない場合は404、
+    // 存在する場合は401が返る
+    expect([401, 404, 405]).toContain(response.status())
+  })
+
+  test('POST /api/schedules で未認証はエラーを返す', async ({ request }) => {
+    const response = await request.post('/api/schedules', {
+      data: {
+        title: 'テスト予定',
+        start: '2025-06-01T09:00:00Z',
+        end: '2025-06-01T10:00:00Z',
+      },
+    })
+    // 未認証の場合、401（認証エラー）または403（CSRF）が返る
+    expect([401, 403]).toContain(response.status())
+  })
+})
+
+test.describe('API: 管理者エンドポイント（未認証）', () => {
+  test('GET /api/admin/audit-logs で未認証は 401', async ({ request }) => {
+    const response = await request.get('/api/admin/audit-logs')
+    expect(response.status()).toBe(401)
+  })
+
+  test('GET /api/admin/dashboard で未認証は 401', async ({ request }) => {
+    const response = await request.get('/api/admin/dashboard')
+    expect(response.status()).toBe(401)
+  })
+
+  test('GET /api/admin/backups で未認証は 401', async ({ request }) => {
+    const response = await request.get('/api/admin/backups')
+    expect(response.status()).toBe(401)
+  })
+})
+
+test.describe('API: エラーページ', () => {
+  test('存在しないAPIパスは 404', async ({ request }) => {
+    const response = await request.get('/api/nonexistent-endpoint')
+    expect([404, 405]).toContain(response.status())
+  })
+})

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * E2E: 認証フロー
+ *
+ * テスト対象:
+ * - ログインページの表示
+ * - ログイン → 週間ボードへリダイレクト
+ * - 認証エラー表示
+ * - ログアウト
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('認証フロー', () => {
+  test('ログインページが正しく表示される', async ({ page }) => {
+    await page.goto('/login')
+
+    // タイトル要素
+    await expect(page.locator('h1')).toContainText('ミエルボード')
+
+    // フォーム要素
+    await expect(page.locator('#email')).toBeVisible()
+    await expect(page.locator('#password')).toBeVisible()
+    await expect(page.locator('button[type="submit"]')).toBeVisible()
+    await expect(page.locator('button[type="submit"]')).toContainText('ログイン')
+
+    // スクリーンショット
+    await page.screenshot({ path: 'tests/e2e/artifacts/login-page.png' })
+  })
+
+  test('空のフォーム送信で HTML5 バリデーションが効く', async ({ page }) => {
+    await page.goto('/login')
+
+    // email は required なので空のまま submit しても送信されない
+    const emailInput = page.locator('#email')
+    await expect(emailInput).toHaveAttribute('required', '')
+  })
+
+  test('不正な認証情報でエラーメッセージが表示される', async ({ page }) => {
+    await page.goto('/login', { waitUntil: 'networkidle' })
+
+    // Hydration 完了を待つ
+    const emailInput = page.locator('#email')
+    const passwordInput = page.locator('#password')
+    const submitButton = page.locator('button[type="submit"]')
+    await expect(emailInput).toBeVisible({ timeout: 10000 })
+    await expect(submitButton).toBeEnabled()
+
+    // クリックして入力フォーカスを確保してからtype
+    await emailInput.click()
+    await emailInput.fill('nonexistent@example.com')
+    await passwordInput.click()
+    await passwordInput.fill('wrongpassword')
+
+    // submit
+    await submitButton.click()
+
+    // エラーメッセージの表示を待機
+    // Vueがエラーをキャッチし .error-message を表示するまで待つ
+    const errorMsg = page.locator('.error-message')
+    await expect(errorMsg).toBeVisible({ timeout: 15000 })
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/login-error.png' })
+  })
+
+  test('ヘルスチェックAPIが正常に動作する', async ({ request }) => {
+    const response = await request.get('/api/health')
+    expect(response.status()).toBe(200)
+
+    const data = await response.json()
+    expect(['healthy', 'degraded']).toContain(data.status)
+    expect(data).toHaveProperty('timestamp')
+  })
+})

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E: ナビゲーション・レスポンシブ
+ *
+ * テスト対象:
+ * - ヘッダーナビゲーション表示
+ * - モバイルハンバーガーメニュー（NAV-005）
+ * - レスポンシブ対応
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('ナビゲーション', () => {
+  test('ヘッダーが表示される', async ({ page }) => {
+    await page.goto('/')
+
+    const header = page.locator('.app-header')
+    await expect(header).toBeVisible()
+
+    // ブランドアイコン
+    await expect(page.locator('.brand-icon')).toContainText('M')
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/header-desktop.png' })
+  })
+
+  test('ログインリンクが未認証時に表示される', async ({ page }) => {
+    await page.goto('/')
+
+    const loginLink = page.locator('.login-link')
+    await expect(loginLink).toBeVisible()
+    await expect(loginLink).toContainText('ログイン')
+  })
+
+  test('ランディングページが表示される', async ({ page }) => {
+    await page.goto('/')
+
+    // ページの基本要素を確認
+    await expect(page).toHaveURL('/')
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/landing-page.png' })
+  })
+})
+
+test.describe('モバイルナビゲーション（NAV-005）', () => {
+  test.use({ viewport: { width: 375, height: 812 } }) // iPhone X
+
+  test('モバイルでハンバーガーメニューが非認証時は非表示', async ({ page }) => {
+    await page.goto('/')
+
+    // 未認証時はハンバーガーメニューは表示されない（ログインリンクのみ）
+    const loginLink = page.locator('.login-link')
+    await expect(loginLink).toBeVisible()
+
+    // デスクトップナビは非表示
+    const mainNav = page.locator('.main-nav')
+    await expect(mainNav).not.toBeVisible()
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/mobile-header.png' })
+  })
+
+  test('モバイルでブランドテキストが非表示', async ({ page }) => {
+    await page.goto('/')
+
+    // ブランドテキストは768px以下で非表示
+    const brandText = page.locator('.brand-text')
+    await expect(brandText).not.toBeVisible()
+
+    // ブランドアイコンは常に表示
+    const brandIcon = page.locator('.brand-icon')
+    await expect(brandIcon).toBeVisible()
+  })
+})
+
+test.describe('レスポンシブ確認', () => {
+  test('デスクトップ幅でのレイアウト', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.goto('/')
+
+    // ブランドテキストが表示される
+    await expect(page.locator('.brand-text')).toBeVisible()
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/desktop-layout.png' })
+  })
+
+  test('タブレット幅でのレイアウト', async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 })
+    await page.goto('/')
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/tablet-layout.png' })
+  })
+
+  test('モバイル幅でのレイアウト', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.goto('/')
+
+    await page.screenshot({ path: 'tests/e2e/artifacts/mobile-layout.png' })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    setupFiles: ['./tests/setup.ts']
+    setupFiles: ['./tests/setup.ts'],
+    exclude: ['node_modules/**', 'tests/e2e/**', '**/*.spec.ts']
   }
 })


### PR DESCRIPTION
## Summary
- Playwright E2Eテスト基盤を構築し、22テスト全通過を確認
- 認証フロー、ナビゲーション、レスポンシブ、APIエンドポイントをカバー
- Vitest設定でE2E `.spec.ts` ファイルを除外し、テストランナーの競合を解消

## テストカバレッジ

| テストスイート | テスト数 | 内容 |
|---|---|---|
| auth.spec.ts | 4 | ログイン画面表示、HTML5バリデーション、認証エラー表示、ヘルスチェックAPI |
| navigation.spec.ts | 8 | ヘッダー表示、ログインリンク、ランディングページ、モバイルメニュー、レスポンシブ(3サイズ) |
| api.spec.ts | 10 | ヘルスチェック、認証API(3件)、スケジュールAPI(2件)、管理者API(3件)、404 |

## 変更ファイル

- `playwright.config.ts` - Chromium設定、devサーバー自動起動
- `tests/e2e/auth.spec.ts` - 認証フローE2Eテスト
- `tests/e2e/navigation.spec.ts` - ナビゲーション・レスポンシブE2Eテスト
- `tests/e2e/api.spec.ts` - APIエンドポイントE2Eテスト
- `vitest.config.ts` - E2Eファイル除外設定追加
- `.gitignore` - playwright-report/、tests/e2e/artifacts/ を除外
- `package.json` / `package-lock.json` - @playwright/test 追加

## Test plan
- [x] `npx playwright test` - 22テスト全通過
- [x] `npm run typecheck` - 型エラーなし
- [x] `npm run test` - ユニットテスト423件全通過（E2Eファイル除外確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)