### PR TITLE
test: P1テストカバレッジ大幅拡充 +143テスト・型安全性改善

### DIFF
--- a/pages/admin/departments.vue
+++ b/pages/admin/departments.vue
@@ -156,8 +156,9 @@ async function saveDepartment() {
     }
     closeModal()
     await fetchDepartments()
-  } catch (error: any) {
-    modalError.value = error.data?.message || '保存に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    modalError.value = (errData?.message as string) || '保存に失敗しました'
   } finally {
     submitting.value = false
   }
@@ -175,8 +176,9 @@ async function deleteDepartment(dept: Department) {
   try {
     await $fetch(`/api/departments/${dept.id}`, { method: 'DELETE' })
     await fetchDepartments()
-  } catch (error: any) {
-    alert(error.data?.message || '削除に失敗しました')
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    alert(errData?.message || '削除に失敗しました')
   }
 }
 

--- a/pages/meetings/[id].vue
+++ b/pages/meetings/[id].vue
@@ -186,8 +186,9 @@ async function submitResponse() {
       body: { candidateIds: selectedCandidates.value }
     })
     await fetchMeeting()
-  } catch (error: any) {
-    alert(error.data?.message || '回答の送信に失敗しました')
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    alert(errData?.message || '回答の送信に失敗しました')
   } finally {
     submitting.value = false
   }
@@ -205,8 +206,9 @@ async function confirmMeeting() {
       body: { candidateId: selectedCandidateForConfirm.value }
     })
     await fetchMeeting()
-  } catch (error: any) {
-    alert(error.data?.message || '確定に失敗しました')
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    alert(errData?.message || '確定に失敗しました')
   } finally {
     submitting.value = false
   }

--- a/pages/settings/calendar.vue
+++ b/pages/settings/calendar.vue
@@ -220,8 +220,9 @@ async function handleConnect() {
     const response = await $fetch<{ redirectUrl: string }>('/api/calendar/google/connect')
     // Redirect to Google OAuth
     window.location.href = response.redirectUrl
-  } catch (error: any) {
-    errorMessage.value = error.data?.statusMessage || 'カレンダー連携の開始に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    errorMessage.value = (errData?.statusMessage as string) || 'カレンダー連携の開始に失敗しました'
     connecting.value = false
   }
 }
@@ -250,8 +251,9 @@ async function handleSync() {
 
     // Refresh connection data
     await fetchConnection()
-  } catch (error: any) {
-    errorMessage.value = error.data?.statusMessage || '同期に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    errorMessage.value = (errData?.statusMessage as string) || '同期に失敗しました'
   } finally {
     syncing.value = false
   }
@@ -275,8 +277,9 @@ async function handleDisconnect() {
     setTimeout(() => {
       successMessage.value = ''
     }, 3000)
-  } catch (error: any) {
-    errorMessage.value = error.data?.statusMessage || '連携の解除に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    errorMessage.value = (errData?.statusMessage as string) || '連携の解除に失敗しました'
   } finally {
     disconnecting.value = false
   }

--- a/pages/settings/password.vue
+++ b/pages/settings/password.vue
@@ -169,8 +169,9 @@ async function handleSubmit() {
         confirmPassword: ''
       }
     }
-  } catch (error: any) {
-    errorMessage.value = error.data?.statusMessage || 'パスワードの変更に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    errorMessage.value = (errData?.statusMessage as string) || 'パスワードの変更に失敗しました'
   } finally {
     submitting.value = false
   }

--- a/pages/settings/profile.vue
+++ b/pages/settings/profile.vue
@@ -183,8 +183,9 @@ async function handleSubmit() {
         successMessage.value = ''
       }, 3000)
     }
-  } catch (error: any) {
-    errorMessage.value = error.data?.statusMessage || '更新に失敗しました'
+  } catch (error: unknown) {
+    const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined
+    errorMessage.value = (errData?.statusMessage as string) || '更新に失敗しました'
   } finally {
     submitting.value = false
   }

--- a/server/api/admin/admin.test.ts
+++ b/server/api/admin/admin.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Admin API Integration Tests
+ *
+ * テスト対象:
+ * - GET  /api/admin/audit-logs
+ * - GET  /api/admin/dashboard
+ * - GET  /api/admin/backups
+ * - POST /api/admin/backups
+ * - GET  /api/admin/llm-settings
+ * - PATCH /api/admin/llm-settings
+ *
+ * 全エンドポイントで ADMIN 権限必須
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ================================================================
+// モック定義（vi.hoisted で変数を事前に定義）
+// ================================================================
+
+const {
+  mockPrisma,
+  mockAuth,
+  mockRequireAdmin,
+  mockGetAuditLogs,
+  mockCreateAuditLog,
+  mockListBackups,
+  mockCreateBackup,
+  mockPruneOldBackups,
+  mockGetAvailableProviders,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    user: {
+      count: vi.fn(),
+    },
+    schedule: {
+      count: vi.fn(),
+    },
+    department: {
+      count: vi.fn(),
+    },
+    auditLog: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    organization: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  mockAuth: vi.fn(),
+  mockRequireAdmin: vi.fn(),
+  mockGetAuditLogs: vi.fn(),
+  mockCreateAuditLog: vi.fn(),
+  mockListBackups: vi.fn(),
+  mockCreateBackup: vi.fn(),
+  mockPruneOldBackups: vi.fn(),
+  mockGetAvailableProviders: vi.fn(),
+}))
+
+// モック登録
+vi.mock('~/server/utils/prisma', () => ({ prisma: mockPrisma }))
+vi.mock('~/server/utils/authMiddleware', () => ({
+  requireAuth: mockAuth,
+  requireAdmin: mockRequireAdmin,
+}))
+vi.mock('~/server/utils/auditLog', () => ({
+  getAuditLogs: mockGetAuditLogs,
+  createAuditLog: mockCreateAuditLog,
+  AUDIT_ACTIONS: {
+    USER_LOGIN: 'USER_LOGIN',
+    USER_LOGOUT: 'USER_LOGOUT',
+    SCHEDULE_CREATE: 'SCHEDULE_CREATE',
+    SCHEDULE_UPDATE: 'SCHEDULE_UPDATE',
+    SCHEDULE_DELETE: 'SCHEDULE_DELETE',
+    ORGANIZATION_UPDATE: 'ORGANIZATION_UPDATE',
+    LLM_SETTINGS_UPDATE: 'LLM_SETTINGS_UPDATE',
+  },
+}))
+vi.mock('~/server/utils/backup', () => ({
+  listBackups: mockListBackups,
+  createBackup: mockCreateBackup,
+  pruneOldBackups: mockPruneOldBackups,
+}))
+vi.mock('~/server/utils/llm/factory', () => ({
+  getAvailableProviders: mockGetAvailableProviders,
+}))
+vi.mock('~/server/utils/llm/provider', () => ({
+  DEFAULT_MODELS: {
+    openai: 'gpt-4o-mini',
+    claude: 'claude-sonnet-4-20250514',
+    gemini: 'gemini-2.0-flash',
+  },
+  PROVIDER_ENV_KEYS: {
+    openai: 'OPENAI_API_KEY',
+    claude: 'ANTHROPIC_API_KEY',
+    gemini: 'GOOGLE_AI_API_KEY',
+  },
+}))
+vi.mock('~/server/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// h3 モック
+vi.mock('h3', async () => {
+  const actual = await vi.importActual('h3')
+  return {
+    ...actual,
+    readBody: (event: { _body: unknown }) => Promise.resolve(event._body),
+    getQuery: (event: { _query: unknown }) => event._query || {},
+  }
+})
+
+// ================================================================
+// ヘルパー
+// ================================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockEvent(overrides: {
+  body?: Record<string, unknown>
+  query?: Record<string, unknown>
+}): any {
+  return {
+    node: {
+      req: {
+        headers: {},
+        url: '/api/admin/test',
+        method: 'GET',
+        socket: { remoteAddress: '127.0.0.1' },
+      },
+      res: {
+        setHeader: vi.fn(),
+        getHeader: vi.fn(),
+      },
+    },
+    context: {},
+    _body: overrides.body,
+    _query: overrides.query,
+  }
+}
+
+const MOCK_ADMIN_AUTH = {
+  userId: 'user-test',
+  organizationId: 'org-test',
+  role: 'ADMIN' as const,
+  email: 'admin@test.com',
+}
+
+const MOCK_MEMBER_AUTH = {
+  userId: 'user-test',
+  organizationId: 'org-test',
+  role: 'MEMBER' as const,
+  email: 'member@test.com',
+}
+
+// ================================================================
+// テスト
+// ================================================================
+
+describe('Admin API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue(MOCK_ADMIN_AUTH)
+    mockRequireAdmin.mockImplementation(() => {
+      // デフォルト: 何もしない（ADMINとして通過）
+    })
+  })
+
+  // ----------------------------------------------------------
+  // GET /api/admin/audit-logs
+  // ----------------------------------------------------------
+  describe('GET /api/admin/audit-logs', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./audit-logs.get')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('ADMIN権限がない場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+      mockRequireAdmin.mockImplementation(() => {
+        throw Object.assign(new Error('管理者権限が必要です'), {
+          statusCode: 403,
+        })
+      })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('正常系: 操作ログ一覧を取得する', async () => {
+      const mockResult = {
+        logs: [
+          {
+            id: 'log-1',
+            action: 'USER_LOGIN',
+            targetId: null,
+            meta: null,
+            userName: 'テストユーザー',
+            createdAt: '2026-01-15T10:00:00.000Z',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 50,
+        totalPages: 1,
+      }
+      mockGetAuditLogs.mockResolvedValue(mockResult)
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockRequireAdmin).toHaveBeenCalledWith(MOCK_ADMIN_AUTH)
+      expect(mockGetAuditLogs).toHaveBeenCalledWith('org-test', {
+        page: 1,
+        limit: 50,
+        action: undefined,
+        userId: undefined,
+        from: undefined,
+        to: undefined,
+      })
+      expect(result).toEqual({
+        success: true,
+        ...mockResult,
+      })
+    })
+
+    it('フィルタ: action, userId, from, to を渡す', async () => {
+      mockGetAuditLogs.mockResolvedValue({
+        logs: [],
+        total: 0,
+        page: 1,
+        limit: 50,
+        totalPages: 0,
+      })
+
+      const event = createMockEvent({
+        query: {
+          action: 'USER_LOGIN',
+          userId: 'user-filter',
+          from: '2026-01-01T00:00:00Z',
+          to: '2026-01-31T23:59:59Z',
+          page: '2',
+          limit: '10',
+        },
+      })
+      const result = await handler(event)
+
+      expect(mockGetAuditLogs).toHaveBeenCalledWith('org-test', {
+        page: 2,
+        limit: 10,
+        action: 'USER_LOGIN',
+        userId: 'user-filter',
+        from: expect.any(Date),
+        to: expect.any(Date),
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('from の日時形式が不正な場合 400 を返す', async () => {
+      const event = createMockEvent({
+        query: { from: 'invalid-date' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('to の日時形式が不正な場合 400 を返す', async () => {
+      const event = createMockEvent({
+        query: { to: 'not-a-date' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // GET /api/admin/dashboard
+  // ----------------------------------------------------------
+  describe('GET /api/admin/dashboard', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./dashboard.get')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('ADMIN権限がない場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+      mockRequireAdmin.mockImplementation(() => {
+        throw Object.assign(new Error('管理者権限が必要です'), {
+          statusCode: 403,
+        })
+      })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('正常系: 統計情報を取得する', async () => {
+      // Promise.all の順番に合わせてモック設定
+      mockPrisma.user.count
+        .mockResolvedValueOnce(10)   // totalUsers
+        .mockResolvedValueOnce(5)    // activeUsers
+      mockPrisma.schedule.count
+        .mockResolvedValueOnce(100)  // totalSchedules
+        .mockResolvedValueOnce(8)    // todaySchedules
+      mockPrisma.department.count.mockResolvedValue(3)  // totalDepartments
+      mockPrisma.auditLog.findMany.mockResolvedValue([
+        {
+          id: 'log-1',
+          action: 'USER_LOGIN',
+          user: { name: 'テストユーザー' },
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+        },
+      ])
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockRequireAdmin).toHaveBeenCalledWith(MOCK_ADMIN_AUTH)
+      expect(result).toEqual({
+        success: true,
+        data: {
+          stats: {
+            totalUsers: 10,
+            activeUsers: 5,
+            totalSchedules: 100,
+            todaySchedules: 8,
+            totalDepartments: 3,
+          },
+          recentActivity: [
+            {
+              id: 'log-1',
+              action: 'USER_LOGIN',
+              userName: 'テストユーザー',
+              createdAt: '2026-01-15T10:00:00.000Z',
+            },
+          ],
+        },
+      })
+
+      // organizationId スコープの確認
+      expect(mockPrisma.user.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: 'org-test' }),
+        })
+      )
+      expect(mockPrisma.schedule.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ organizationId: 'org-test' }),
+        })
+      )
+      expect(mockPrisma.department.count).toHaveBeenCalledWith({
+        where: { organizationId: 'org-test' },
+      })
+      expect(mockPrisma.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: 'org-test' },
+        })
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // GET /api/admin/backups
+  // ----------------------------------------------------------
+  describe('GET /api/admin/backups', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./backups/index.get')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('非ADMINの場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('正常系: バックアップ一覧を取得する', async () => {
+      const mockBackups = [
+        {
+          filename: 'backup-2026-01-15-manual.sql.gz',
+          type: 'manual',
+          size: 1024,
+          createdAt: '2026-01-15T10:00:00.000Z',
+        },
+        {
+          filename: 'backup-2026-01-14-auto.sql.gz',
+          type: 'auto',
+          size: 2048,
+          createdAt: '2026-01-14T03:00:00.000Z',
+        },
+      ]
+      mockListBackups.mockReturnValue(mockBackups)
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockListBackups).toHaveBeenCalled()
+      expect(result).toEqual({
+        success: true,
+        backups: mockBackups,
+        total: 2,
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // POST /api/admin/backups
+  // ----------------------------------------------------------
+  describe('POST /api/admin/backups', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./backups/index.post')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('非ADMINの場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('正常系: バックアップを作成する', async () => {
+      const mockBackup = {
+        filename: 'backup-2026-01-15-manual.sql.gz',
+        type: 'manual',
+        size: 1024,
+        createdAt: '2026-01-15T10:00:00.000Z',
+      }
+      mockCreateBackup.mockReturnValue(mockBackup)
+      mockPruneOldBackups.mockReturnValue(2)
+      mockCreateAuditLog.mockResolvedValue(undefined)
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockCreateBackup).toHaveBeenCalledWith('manual')
+      expect(mockPruneOldBackups).toHaveBeenCalled()
+      expect(mockCreateAuditLog).toHaveBeenCalledWith({
+        organizationId: 'org-test',
+        userId: 'user-test',
+        action: 'ORGANIZATION_UPDATE',
+        meta: {
+          type: 'backup_create',
+          filename: mockBackup.filename,
+          pruned: '2',
+        },
+      })
+      expect(result).toEqual({
+        success: true,
+        backup: mockBackup,
+        pruned: 2,
+      })
+    })
+
+    it('バックアップ作成に失敗した場合 500 を返す', async () => {
+      mockCreateBackup.mockReturnValue(null)
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 500,
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // GET /api/admin/llm-settings
+  // ----------------------------------------------------------
+  describe('GET /api/admin/llm-settings', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./llm-settings.get')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('ADMIN権限がない場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+      mockRequireAdmin.mockImplementation(() => {
+        throw Object.assign(new Error('管理者権限が必要です'), {
+          statusCode: 403,
+        })
+      })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('正常系: LLM設定を取得する', async () => {
+      mockPrisma.organization.findUnique.mockResolvedValue({
+        llmProvider: 'claude',
+        llmModel: 'claude-sonnet-4-20250514',
+      })
+      mockGetAvailableProviders.mockReturnValue(['openai', 'claude'])
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockRequireAdmin).toHaveBeenCalledWith(MOCK_ADMIN_AUTH)
+      expect(mockPrisma.organization.findUnique).toHaveBeenCalledWith({
+        where: { id: 'org-test' },
+        select: { llmProvider: true, llmModel: true },
+      })
+      expect(result).toEqual({
+        success: true,
+        data: {
+          currentProvider: 'claude',
+          currentModel: 'claude-sonnet-4-20250514',
+          providers: [
+            {
+              type: 'openai',
+              name: 'OpenAI (GPT-4o mini)',
+              defaultModel: 'gpt-4o-mini',
+              envKey: 'OPENAI_API_KEY',
+              isConfigured: true,
+            },
+            {
+              type: 'claude',
+              name: 'Claude (Sonnet)',
+              defaultModel: 'claude-sonnet-4-20250514',
+              envKey: 'ANTHROPIC_API_KEY',
+              isConfigured: true,
+            },
+            {
+              type: 'gemini',
+              name: 'Gemini (Flash)',
+              defaultModel: 'gemini-2.0-flash',
+              envKey: 'GOOGLE_AI_API_KEY',
+              isConfigured: false,
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // PATCH /api/admin/llm-settings
+  // ----------------------------------------------------------
+  describe('PATCH /api/admin/llm-settings', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./llm-settings.patch')
+      handler = mod.default
+    })
+
+    it('認証なしの場合 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('認証が必要です'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({ body: { llmProvider: 'openai' } })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('ADMIN権限がない場合 403 を返す', async () => {
+      mockAuth.mockResolvedValue(MOCK_MEMBER_AUTH)
+      mockRequireAdmin.mockImplementation(() => {
+        throw Object.assign(new Error('管理者権限が必要です'), {
+          statusCode: 403,
+        })
+      })
+
+      const event = createMockEvent({ body: { llmProvider: 'openai' } })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('不正なプロバイダーの場合 400 を返す', async () => {
+      const event = createMockEvent({
+        body: { llmProvider: 'invalid-provider' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('プロバイダー未指定の場合 400 を返す', async () => {
+      const event = createMockEvent({
+        body: {},
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('モデル名が100文字を超える場合 400 を返す', async () => {
+      const longModelName = 'a'.repeat(101)
+      const event = createMockEvent({
+        body: { llmProvider: 'openai', llmModel: longModelName },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('モデル名に不正文字が含まれる場合 400 を返す', async () => {
+      const event = createMockEvent({
+        body: { llmProvider: 'openai', llmModel: 'model name with spaces!' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('正常系: LLM設定を更新する（プロバイダーのみ）', async () => {
+      mockPrisma.organization.update.mockResolvedValue({
+        llmProvider: 'openai',
+        llmModel: null,
+      })
+
+      const event = createMockEvent({
+        body: { llmProvider: 'openai' },
+      })
+      const result = await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+      expect(mockRequireAdmin).toHaveBeenCalledWith(MOCK_ADMIN_AUTH)
+      expect(mockPrisma.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-test' },
+        data: {
+          llmProvider: 'openai',
+          llmModel: null,
+        },
+        select: { llmProvider: true, llmModel: true },
+      })
+      expect(result).toEqual({
+        success: true,
+        data: {
+          currentProvider: 'openai',
+          currentModel: null,
+        },
+      })
+    })
+
+    it('正常系: LLM設定を更新する（プロバイダー＋モデル名）', async () => {
+      mockPrisma.organization.update.mockResolvedValue({
+        llmProvider: 'claude',
+        llmModel: 'claude-sonnet-4-20250514',
+      })
+
+      const event = createMockEvent({
+        body: {
+          llmProvider: 'claude',
+          llmModel: 'claude-sonnet-4-20250514',
+        },
+      })
+      const result = await handler(event)
+
+      expect(mockPrisma.organization.update).toHaveBeenCalledWith({
+        where: { id: 'org-test' },
+        data: {
+          llmProvider: 'claude',
+          llmModel: 'claude-sonnet-4-20250514',
+        },
+        select: { llmProvider: true, llmModel: true },
+      })
+      expect(result).toEqual({
+        success: true,
+        data: {
+          currentProvider: 'claude',
+          currentModel: 'claude-sonnet-4-20250514',
+        },
+      })
+    })
+
+    it('モデル名にスラッシュ・コロン・ドットを含む名前は許可される', async () => {
+      mockPrisma.organization.update.mockResolvedValue({
+        llmProvider: 'gemini',
+        llmModel: 'gemini-2.0-flash',
+      })
+
+      const event = createMockEvent({
+        body: {
+          llmProvider: 'gemini',
+          llmModel: 'gemini-2.0-flash',
+        },
+      })
+      const result = await handler(event)
+
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/server/api/auth/otp/otp.test.ts
+++ b/server/api/auth/otp/otp.test.ts
@@ -1,0 +1,452 @@
+/**
+ * OTP API Integration Tests
+ *
+ * テスト対象:
+ * - POST /api/auth/otp/send
+ * - POST /api/auth/otp/verify
+ * - GET /api/auth/otp/status
+ *
+ * 課金操作 2FA のための OTP エンドポイント統合テスト
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ================================================================
+// モック定義（vi.hoisted で変数を事前に定義）
+// ================================================================
+
+const {
+  mockAuth,
+  mockCreateOtp,
+  mockVerifyOtp,
+  mockSendEmail,
+  mockBuildOtpEmail,
+  mockCheckRateLimit,
+  mockGetClientIp,
+  mockSetOtpVerified,
+  mockIsOtpVerified,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCreateOtp: vi.fn(),
+  mockVerifyOtp: vi.fn(),
+  mockSendEmail: vi.fn(),
+  mockBuildOtpEmail: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockGetClientIp: vi.fn(),
+  mockSetOtpVerified: vi.fn(),
+  mockIsOtpVerified: vi.fn(),
+}))
+
+// モック登録
+vi.mock('~/server/utils/authMiddleware', () => ({
+  requireAuth: mockAuth,
+}))
+
+vi.mock('~/server/utils/otp', () => ({
+  createOtp: mockCreateOtp,
+  verifyOtp: mockVerifyOtp,
+  OTP_VERIFIED_DURATION_MS: 30 * 60 * 1000,
+}))
+
+vi.mock('~/server/utils/email', () => ({
+  sendEmail: mockSendEmail,
+  buildOtpEmail: mockBuildOtpEmail,
+}))
+
+vi.mock('~/server/utils/rateLimit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIp: mockGetClientIp,
+}))
+
+vi.mock('~/server/utils/session', () => ({
+  setOtpVerified: mockSetOtpVerified,
+  isOtpVerified: mockIsOtpVerified,
+}))
+
+vi.mock('~/server/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+// h3 モック
+vi.mock('h3', async () => {
+  const actual = await vi.importActual('h3')
+  return {
+    ...actual,
+    readBody: (event: { _body: unknown }) => Promise.resolve(event._body),
+    getCookie: (event: { _cookies?: Record<string, string> }, name: string) => {
+      return event._cookies?.[name] || undefined
+    },
+  }
+})
+
+// ================================================================
+// ヘルパー
+// ================================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockEvent(overrides: {
+  body?: Record<string, unknown>
+  cookies?: Record<string, string>
+}): any {
+  return {
+    node: {
+      req: {
+        headers: {},
+        url: '/api/auth/otp/test',
+        method: 'POST',
+        socket: { remoteAddress: '127.0.0.1' },
+      },
+      res: {
+        setHeader: vi.fn(),
+        getHeader: vi.fn(),
+      },
+    },
+    context: {},
+    _body: overrides.body,
+    _cookies: overrides.cookies,
+  }
+}
+
+const MOCK_AUTH_ADMIN = {
+  userId: 'user-1',
+  organizationId: 'org-1',
+  email: 'admin@example.com',
+  role: 'ADMIN' as const,
+}
+
+// ================================================================
+// テスト
+// ================================================================
+
+describe('OTP API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth.mockResolvedValue(MOCK_AUTH_ADMIN)
+    mockGetClientIp.mockReturnValue('127.0.0.1')
+    mockCheckRateLimit.mockReturnValue({
+      allowed: true,
+      current: 1,
+      remaining: 2,
+      retryAfterSeconds: 0,
+    })
+  })
+
+  // ----------------------------------------------------------
+  // POST /api/auth/otp/send
+  // ----------------------------------------------------------
+  describe('POST /api/auth/otp/send', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./send.post')
+      handler = mod.default
+    })
+
+    it('未認証で 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('Unauthorized'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('非 ADMIN で 403 を返す', async () => {
+      mockAuth.mockResolvedValue({ ...MOCK_AUTH_ADMIN, role: 'MEMBER' })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('email 未設定で 401 を返す', async () => {
+      mockAuth.mockResolvedValue({
+        ...MOCK_AUTH_ADMIN,
+        email: undefined,
+      })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('レート制限超過で 429 を返す', async () => {
+      mockCheckRateLimit.mockReturnValue({
+        allowed: false,
+        current: 4,
+        remaining: 0,
+        retryAfterSeconds: 120,
+      })
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 429,
+      })
+    })
+
+    it('正常系: OTP 生成・メール送信成功', async () => {
+      mockCreateOtp.mockResolvedValue('123456')
+      mockBuildOtpEmail.mockReturnValue({
+        subject: '【ミエルプラス】認証コード',
+        html: '<p>123456</p>',
+      })
+      mockSendEmail.mockResolvedValue({ success: true })
+
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      // requireAuth が呼ばれていること
+      expect(mockAuth).toHaveBeenCalledWith(event)
+
+      // OTP が生成されていること
+      expect(mockCreateOtp).toHaveBeenCalledWith({
+        userId: 'user-1',
+        purpose: 'billing',
+      })
+
+      // メールテンプレートが構築されていること
+      expect(mockBuildOtpEmail).toHaveBeenCalledWith({ code: '123456' })
+
+      // メールが送信されていること
+      expect(mockSendEmail).toHaveBeenCalledWith({
+        to: 'admin@example.com',
+        subject: '【ミエルプラス】認証コード',
+        html: '<p>123456</p>',
+      })
+
+      // レスポンスが正しいこと
+      expect(result).toEqual({
+        success: true,
+        message: '認証コードをメールに送信しました',
+      })
+    })
+
+    it('レート制限チェックに正しい識別子を渡す', async () => {
+      mockGetClientIp.mockReturnValue('192.168.1.100')
+      mockCreateOtp.mockResolvedValue('654321')
+      mockBuildOtpEmail.mockReturnValue({ subject: 'test', html: '<p>test</p>' })
+      mockSendEmail.mockResolvedValue({ success: true })
+
+      const event = createMockEvent({})
+      await handler(event)
+
+      expect(mockCheckRateLimit).toHaveBeenCalledWith(
+        'otp:192.168.1.100',
+        expect.objectContaining({
+          maxRequests: 3,
+          windowMs: 5 * 60 * 1000,
+        })
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // POST /api/auth/otp/verify
+  // ----------------------------------------------------------
+  describe('POST /api/auth/otp/verify', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./verify.post')
+      handler = mod.default
+    })
+
+    it('未認証で 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('Unauthorized'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({ body: { code: '123456' } })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('非 ADMIN で 403 を返す', async () => {
+      mockAuth.mockResolvedValue({ ...MOCK_AUTH_ADMIN, role: 'MEMBER' })
+
+      const event = createMockEvent({ body: { code: '123456' } })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 403,
+      })
+    })
+
+    it('code なしで 400 を返す', async () => {
+      const event = createMockEvent({ body: {} })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('不正な code 形式（6桁でない）で 400 を返す', async () => {
+      // 5桁
+      const event5 = createMockEvent({ body: { code: '12345' } })
+      await expect(handler(event5)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+
+      // 7桁
+      const event7 = createMockEvent({ body: { code: '1234567' } })
+      await expect(handler(event7)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+
+      // 英字混在
+      const eventAlpha = createMockEvent({ body: { code: '12ab56' } })
+      await expect(handler(eventAlpha)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('無効な code で 401 を返す', async () => {
+      mockVerifyOtp.mockResolvedValue(false)
+
+      const event = createMockEvent({ body: { code: '000000' } })
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+
+      expect(mockVerifyOtp).toHaveBeenCalledWith({
+        userId: 'user-1',
+        purpose: 'billing',
+        code: '000000',
+      })
+    })
+
+    it('正常系: 検証成功、セッションにフラグ設定', async () => {
+      mockVerifyOtp.mockResolvedValue(true)
+      mockSetOtpVerified.mockReturnValue(true)
+
+      const event = createMockEvent({
+        body: { code: '123456' },
+        cookies: { session_id: 'sess-abc-123' },
+      })
+      const result = await handler(event)
+
+      // requireAuth が呼ばれていること
+      expect(mockAuth).toHaveBeenCalledWith(event)
+
+      // verifyOtp が正しいパラメータで呼ばれていること
+      expect(mockVerifyOtp).toHaveBeenCalledWith({
+        userId: 'user-1',
+        purpose: 'billing',
+        code: '123456',
+      })
+
+      // セッションに OTP 検証済みフラグが設定されていること
+      expect(mockSetOtpVerified).toHaveBeenCalledWith(
+        'sess-abc-123',
+        30 * 60 * 1000 // OTP_VERIFIED_DURATION_MS
+      )
+
+      // レスポンスが正しいこと
+      expect(result).toEqual({
+        success: true,
+        message: '認証に成功しました',
+        verifiedUntil: expect.any(String),
+      })
+    })
+
+    it('セッション ID がない場合でも検証自体は成功する', async () => {
+      mockVerifyOtp.mockResolvedValue(true)
+
+      const event = createMockEvent({
+        body: { code: '123456' },
+        // cookies なし → session_id = undefined
+      })
+      const result = await handler(event)
+
+      // setOtpVerified は呼ばれない（sessionId が falsy）
+      expect(mockSetOtpVerified).not.toHaveBeenCalled()
+
+      // 検証自体は成功する
+      expect(result.success).toBe(true)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // GET /api/auth/otp/status
+  // ----------------------------------------------------------
+  describe('GET /api/auth/otp/status', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let handler: any
+
+    beforeEach(async () => {
+      const mod = await import('./status.get')
+      handler = mod.default
+    })
+
+    it('未認証で 401 を返す', async () => {
+      mockAuth.mockRejectedValue(
+        Object.assign(new Error('Unauthorized'), { statusCode: 401 })
+      )
+
+      const event = createMockEvent({})
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 401,
+      })
+    })
+
+    it('セッションなし（cookie なし）で verified: false を返す', async () => {
+      const event = createMockEvent({})
+      // cookies が未定義 → getCookie は undefined を返す
+      const result = await handler(event)
+
+      expect(result).toEqual({ verified: false })
+      // isOtpVerified は呼ばれない（sessionId が falsy）
+      expect(mockIsOtpVerified).not.toHaveBeenCalled()
+    })
+
+    it('OTP 未検証の場合 verified: false を返す', async () => {
+      mockIsOtpVerified.mockReturnValue(false)
+
+      const event = createMockEvent({
+        cookies: { session_id: 'sess-abc-123' },
+      })
+      const result = await handler(event)
+
+      expect(mockIsOtpVerified).toHaveBeenCalledWith('sess-abc-123')
+      expect(result).toEqual({ verified: false })
+    })
+
+    it('OTP 検証済みの場合 verified: true を返す', async () => {
+      mockIsOtpVerified.mockReturnValue(true)
+
+      const event = createMockEvent({
+        cookies: { session_id: 'sess-abc-123' },
+      })
+      const result = await handler(event)
+
+      expect(mockIsOtpVerified).toHaveBeenCalledWith('sess-abc-123')
+      expect(result).toEqual({ verified: true })
+    })
+
+    it('requireAuth が必ず呼ばれること（認証チェック）', async () => {
+      mockIsOtpVerified.mockReturnValue(false)
+
+      const event = createMockEvent({
+        cookies: { session_id: 'sess-xyz' },
+      })
+      await handler(event)
+
+      expect(mockAuth).toHaveBeenCalledWith(event)
+    })
+  })
+})

--- a/server/api/billing/webhook.test.ts
+++ b/server/api/billing/webhook.test.ts
@@ -1,0 +1,976 @@
+/**
+ * Stripe Webhook Integration Tests
+ *
+ * テスト対象: POST /api/billing/webhook
+ *
+ * Stripe 署名検証 → イベントタイプ別ハンドリングの統合テスト
+ * 金銭処理に直結するため、全分岐を網羅する
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ================================================================
+// モック定義（vi.hoisted で変数を事前に定義）
+// ================================================================
+
+const {
+  mockPrisma,
+  mockStripe,
+  mockAiCredits,
+  mockEnv,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    subscription: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+  mockStripe: {
+    webhooks: { constructEvent: vi.fn() },
+    subscriptions: { retrieve: vi.fn() },
+    products: { retrieve: vi.fn() },
+    prices: { retrieve: vi.fn() },
+  },
+  mockAiCredits: {
+    resetMonthlyCredits: vi.fn(),
+    initializeCredits: vi.fn(),
+    grantPackCredits: vi.fn(),
+  },
+  mockEnv: {
+    STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
+  },
+}))
+
+// モック登録
+vi.mock('~/server/utils/prisma', () => ({ prisma: mockPrisma }))
+vi.mock('~/server/utils/stripe', () => ({
+  stripe: mockStripe,
+  PLAN_LIMITS: {
+    STARTER: { maxUsers: 10, monthlyAiCredits: 150, features: ['board'] },
+    BUSINESS: { maxUsers: 30, monthlyAiCredits: 400, features: ['board', 'calendar', 'signage'] },
+    ENTERPRISE: { maxUsers: -1, monthlyAiCredits: -1, features: ['board', 'calendar', 'signage', 'api'] },
+  },
+}))
+vi.mock('~/server/utils/aiCredits', () => mockAiCredits)
+vi.mock('~/server/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// h3 モック
+vi.mock('h3', async () => {
+  const actual = await vi.importActual('h3')
+  return {
+    ...actual,
+    readRawBody: (event: { _rawBody: unknown }) => Promise.resolve(event._rawBody),
+    getHeader: (_event: unknown, name: string) => {
+      const headers = (_event as { _headers?: Record<string, string> })._headers || {}
+      return headers[name]
+    },
+  }
+})
+
+// ================================================================
+// ヘルパー
+// ================================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockEvent(overrides: {
+  rawBody?: string
+  headers?: Record<string, string>
+}): any {
+  return {
+    node: {
+      req: {
+        headers: overrides.headers || {},
+        url: '/api/billing/webhook',
+        method: 'POST',
+        socket: { remoteAddress: '127.0.0.1' },
+      },
+      res: {
+        setHeader: vi.fn(),
+        getHeader: vi.fn(),
+      },
+    },
+    context: {},
+    _rawBody: overrides.rawBody,
+    _headers: overrides.headers,
+  }
+}
+
+/**
+ * Stripe.Event オブジェクトの簡易ファクトリ
+ */
+function createStripeEvent(
+  type: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dataObject: Record<string, any>
+) {
+  return {
+    id: `evt_test_${Date.now()}`,
+    object: 'event' as const,
+    type,
+    data: {
+      object: dataObject,
+    },
+    api_version: '2025-01-27.acacia',
+    created: Math.floor(Date.now() / 1000),
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+  }
+}
+
+/**
+ * Stripe.Subscription のモックファクトリ
+ */
+function createMockSubscription(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sub_test_123',
+    status: 'active',
+    metadata: { organizationId: 'org-1' },
+    items: {
+      data: [{
+        price: {
+          id: 'price_test_123',
+          product: 'prod_test_123',
+          recurring: { interval: 'month' },
+        },
+        current_period_start: 1700000000,
+        current_period_end: 1702592000,
+      }],
+    },
+    trial_end: null,
+    canceled_at: null,
+    ...overrides,
+  }
+}
+
+// ================================================================
+// テスト
+// ================================================================
+
+describe('POST /api/billing/webhook', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // 環境変数を設定
+    process.env.STRIPE_WEBHOOK_SECRET = mockEnv.STRIPE_WEBHOOK_SECRET
+    // モジュールをリセットして再インポート（環境変数の変更を反映）
+    vi.resetModules()
+    // モック再登録
+    vi.doMock('~/server/utils/prisma', () => ({ prisma: mockPrisma }))
+    vi.doMock('~/server/utils/stripe', () => ({
+      stripe: mockStripe,
+      PLAN_LIMITS: {
+        STARTER: { maxUsers: 10, monthlyAiCredits: 150, features: ['board'] },
+        BUSINESS: { maxUsers: 30, monthlyAiCredits: 400, features: ['board', 'calendar', 'signage'] },
+        ENTERPRISE: { maxUsers: -1, monthlyAiCredits: -1, features: ['board', 'calendar', 'signage', 'api'] },
+      },
+    }))
+    vi.doMock('~/server/utils/aiCredits', () => mockAiCredits)
+    vi.doMock('~/server/utils/logger', () => ({
+      createLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+    }))
+    vi.doMock('h3', async () => {
+      const actual = await vi.importActual('h3')
+      return {
+        ...actual,
+        readRawBody: (event: { _rawBody: unknown }) => Promise.resolve(event._rawBody),
+        getHeader: (_event: unknown, name: string) => {
+          const headers = (_event as { _headers?: Record<string, string> })._headers || {}
+          return headers[name]
+        },
+      }
+    })
+    const mod = await import('./webhook.post')
+    handler = mod.default
+  })
+
+  // ----------------------------------------------------------
+  // 署名検証・バリデーション
+  // ----------------------------------------------------------
+  describe('署名検証・バリデーション', () => {
+    it('リクエストボディが空の場合 400 を返す', async () => {
+      const event = createMockEvent({
+        rawBody: undefined,
+        headers: { 'stripe-signature': 'sig_test' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('stripe-signature ヘッダーが未設定の場合 400 を返す', async () => {
+      const event = createMockEvent({
+        rawBody: '{"type":"test"}',
+        headers: {},
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+
+    it('STRIPE_WEBHOOK_SECRET 環境変数が未設定の場合 500 を返す', async () => {
+      delete process.env.STRIPE_WEBHOOK_SECRET
+
+      // 環境変数変更後にモジュール再インポート
+      vi.resetModules()
+      vi.doMock('~/server/utils/prisma', () => ({ prisma: mockPrisma }))
+      vi.doMock('~/server/utils/stripe', () => ({
+        stripe: mockStripe,
+        PLAN_LIMITS: {
+          STARTER: { maxUsers: 10, monthlyAiCredits: 150, features: ['board'] },
+          BUSINESS: { maxUsers: 30, monthlyAiCredits: 400, features: ['board', 'calendar', 'signage'] },
+          ENTERPRISE: { maxUsers: -1, monthlyAiCredits: -1, features: ['board', 'calendar', 'signage', 'api'] },
+        },
+      }))
+      vi.doMock('~/server/utils/aiCredits', () => mockAiCredits)
+      vi.doMock('~/server/utils/logger', () => ({
+        createLogger: () => ({
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        }),
+      }))
+      vi.doMock('h3', async () => {
+        const actual = await vi.importActual('h3')
+        return {
+          ...actual,
+          readRawBody: (event: { _rawBody: unknown }) => Promise.resolve(event._rawBody),
+          getHeader: (_event: unknown, name: string) => {
+            const headers = (_event as { _headers?: Record<string, string> })._headers || {}
+            return headers[name]
+          },
+        }
+      })
+      const mod = await import('./webhook.post')
+      const freshHandler = mod.default
+
+      const event = createMockEvent({
+        rawBody: '{"type":"test"}',
+        headers: { 'stripe-signature': 'sig_test' },
+      })
+
+      await expect(freshHandler(event)).rejects.toMatchObject({
+        statusCode: 500,
+      })
+    })
+
+    it('署名検証失敗（constructEvent が例外）の場合 400 を返す', async () => {
+      mockStripe.webhooks.constructEvent.mockImplementation(() => {
+        throw new Error('Signature verification failed')
+      })
+
+      const event = createMockEvent({
+        rawBody: '{"type":"test"}',
+        headers: { 'stripe-signature': 'sig_invalid' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // checkout.session.completed
+  // ----------------------------------------------------------
+  describe('checkout.session.completed', () => {
+    it('サブスクリプション契約完了時に syncSubscription が呼ばれる', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('checkout.session.completed', {
+        mode: 'subscription',
+        subscription: 'sub_test_123',
+        metadata: { organizationId: 'org-1' },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.subscriptions.retrieve.mockResolvedValue(mockSub)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'ビジネスプラン',
+        metadata: { planType: 'BUSINESS' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"checkout.session.completed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // syncSubscription が実行されたことを検証
+      expect(mockStripe.subscriptions.retrieve).toHaveBeenCalledWith('sub_test_123')
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: 'org-1' },
+          create: expect.objectContaining({
+            organizationId: 'org-1',
+            planType: 'BUSINESS',
+          }),
+          update: expect.objectContaining({
+            planType: 'BUSINESS',
+          }),
+        })
+      )
+      expect(mockAiCredits.initializeCredits).toHaveBeenCalledWith('org-1', 400)
+      expect(result).toEqual({ received: true })
+    })
+
+    it('credit_pack タイプの場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('checkout.session.completed', {
+        mode: 'subscription',
+        subscription: 'sub_test_123',
+        metadata: { organizationId: 'org-1', type: 'credit_pack' },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"checkout.session.completed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // subscriptions.retrieve が呼ばれないことを確認（スキップ）
+      expect(mockStripe.subscriptions.retrieve).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+
+    it('metadata に organizationId がない場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('checkout.session.completed', {
+        mode: 'subscription',
+        subscription: 'sub_test_123',
+        metadata: {},
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"checkout.session.completed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // subscriptions.retrieve が呼ばれないことを確認
+      expect(mockStripe.subscriptions.retrieve).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+
+    it('mode が subscription でない場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('checkout.session.completed', {
+        mode: 'payment',
+        subscription: null,
+        metadata: { organizationId: 'org-1' },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"checkout.session.completed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockStripe.subscriptions.retrieve).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // customer.subscription.updated
+  // ----------------------------------------------------------
+  describe('customer.subscription.updated', () => {
+    it('metadata に organizationId がある場合 syncSubscription が呼ばれる', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'ビジネスプラン',
+        metadata: { planType: 'BUSINESS' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: 'org-1' },
+        })
+      )
+      expect(result).toEqual({ received: true })
+    })
+
+    it('metadata がない場合、DB から organizationId を検索して sync する', async () => {
+      const mockSubWithoutMeta = createMockSubscription({
+        metadata: {}, // organizationId なし
+      })
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSubWithoutMeta)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      // DB に既存レコードがある
+      mockPrisma.subscription.findUnique.mockResolvedValue({
+        organizationId: 'org-from-db',
+        stripeSubscriptionId: 'sub_test_123',
+      })
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'ビジネスプラン',
+        metadata: { planType: 'BUSINESS' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // DB から検索されたことを確認
+      expect(mockPrisma.subscription.findUnique).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_test_123' },
+      })
+      // DB から取得した organizationId で sync されることを確認
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organizationId: 'org-from-db' },
+        })
+      )
+      expect(result).toEqual({ received: true })
+    })
+
+    it('metadata がなく DB にもレコードがない場合はスキップ', async () => {
+      const mockSubWithoutMeta = createMockSubscription({
+        metadata: {},
+      })
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSubWithoutMeta)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.findUnique.mockResolvedValue(null)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // customer.subscription.deleted
+  // ----------------------------------------------------------
+  describe('customer.subscription.deleted', () => {
+    it('サブスクリプションのステータスを CANCELED に更新する', async () => {
+      const stripeEvent = createStripeEvent('customer.subscription.deleted', {
+        id: 'sub_canceled_123',
+        metadata: {},
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 })
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.deleted"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_canceled_123' },
+        data: {
+          status: 'CANCELED',
+          canceledAt: expect.any(Date),
+        },
+      })
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // invoice.paid
+  // ----------------------------------------------------------
+  describe('invoice.paid', () => {
+    it('月次支払い成功時に resetMonthlyCredits が呼ばれる', async () => {
+      const stripeEvent = createStripeEvent('invoice.paid', {
+        id: 'inv_test_123',
+        parent: {
+          subscription_details: {
+            subscription: 'sub_test_123',
+          },
+        },
+        lines: { data: [] },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        stripeSubscriptionId: 'sub_test_123',
+      })
+      mockAiCredits.resetMonthlyCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.paid"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockAiCredits.resetMonthlyCredits).toHaveBeenCalledWith('org-1')
+      expect(result).toEqual({ received: true })
+    })
+
+    it('クレジットパック購入の場合 grantPackCredits が呼ばれる', async () => {
+      const stripeEvent = createStripeEvent('invoice.paid', {
+        id: 'inv_pack_123',
+        parent: {
+          subscription_details: {
+            subscription: 'sub_test_123',
+          },
+        },
+        lines: {
+          data: [{
+            pricing: {
+              price_details: {
+                price: 'price_pack_100',
+              },
+            },
+          }],
+        },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.findUnique.mockResolvedValue({
+        organizationId: 'org-1',
+        stripeSubscriptionId: 'sub_test_123',
+      })
+      // price → product → metadata.credits の検索チェーン
+      mockStripe.prices.retrieve.mockResolvedValue({
+        id: 'price_pack_100',
+        product: 'prod_pack_100',
+      })
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_pack_100',
+        name: '100クレジットパック',
+        metadata: { credits: '100' },
+      })
+      mockAiCredits.grantPackCredits.mockResolvedValue(undefined)
+      mockAiCredits.resetMonthlyCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.paid"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // grantPackCredits が正しいパラメータで呼ばれることを確認
+      expect(mockAiCredits.grantPackCredits).toHaveBeenCalledWith(
+        'org-1',
+        100,
+        '100クレジットパック',
+        'inv_pack_123',
+      )
+      // 通常の月次リセットも実行されることを確認
+      expect(mockAiCredits.resetMonthlyCredits).toHaveBeenCalledWith('org-1')
+      expect(result).toEqual({ received: true })
+    })
+
+    it('subscription 参照がオブジェクト形式の場合も正しく処理する', async () => {
+      const stripeEvent = createStripeEvent('invoice.paid', {
+        id: 'inv_test_456',
+        parent: {
+          subscription_details: {
+            subscription: { id: 'sub_obj_123' }, // オブジェクト形式
+          },
+        },
+        lines: { data: [] },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.findUnique.mockResolvedValue({
+        organizationId: 'org-2',
+        stripeSubscriptionId: 'sub_obj_123',
+      })
+      mockAiCredits.resetMonthlyCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.paid"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.findUnique).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_obj_123' },
+      })
+      expect(mockAiCredits.resetMonthlyCredits).toHaveBeenCalledWith('org-2')
+      expect(result).toEqual({ received: true })
+    })
+
+    it('subscription 参照がない場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('invoice.paid', {
+        id: 'inv_no_sub',
+        parent: null,
+        lines: { data: [] },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.paid"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.findUnique).not.toHaveBeenCalled()
+      expect(mockAiCredits.resetMonthlyCredits).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+
+    it('DB にサブスクリプションが存在しない場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('invoice.paid', {
+        id: 'inv_orphan',
+        parent: {
+          subscription_details: {
+            subscription: 'sub_nonexistent',
+          },
+        },
+        lines: { data: [] },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.findUnique.mockResolvedValue(null)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.paid"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockAiCredits.resetMonthlyCredits).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // invoice.payment_failed
+  // ----------------------------------------------------------
+  describe('invoice.payment_failed', () => {
+    it('支払い失敗時にステータスを PAST_DUE に更新する', async () => {
+      const stripeEvent = createStripeEvent('invoice.payment_failed', {
+        id: 'inv_failed_123',
+        parent: {
+          subscription_details: {
+            subscription: 'sub_failed_123',
+          },
+        },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 })
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.payment_failed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_failed_123' },
+        data: { status: 'PAST_DUE' },
+      })
+      expect(result).toEqual({ received: true })
+    })
+
+    it('subscription 参照がオブジェクト形式の場合も正しく処理する', async () => {
+      const stripeEvent = createStripeEvent('invoice.payment_failed', {
+        id: 'inv_failed_456',
+        parent: {
+          subscription_details: {
+            subscription: { id: 'sub_failed_obj' },
+          },
+        },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockPrisma.subscription.updateMany.mockResolvedValue({ count: 1 })
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.payment_failed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.updateMany).toHaveBeenCalledWith({
+        where: { stripeSubscriptionId: 'sub_failed_obj' },
+        data: { status: 'PAST_DUE' },
+      })
+      expect(result).toEqual({ received: true })
+    })
+
+    it('subscription 参照がない場合はスキップする', async () => {
+      const stripeEvent = createStripeEvent('invoice.payment_failed', {
+        id: 'inv_failed_no_sub',
+        parent: null,
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"invoice.payment_failed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(mockPrisma.subscription.updateMany).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // 未処理イベント
+  // ----------------------------------------------------------
+  describe('未処理イベントタイプ', () => {
+    it('未対応のイベントタイプでも received: true を返す', async () => {
+      const stripeEvent = createStripeEvent('customer.created', {
+        id: 'cus_new_123',
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.created"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      expect(result).toEqual({ received: true })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // ハンドラー内エラー
+  // ----------------------------------------------------------
+  describe('ハンドラー内エラー', () => {
+    it('イベント処理中にエラーが発生した場合 500 を返す', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('checkout.session.completed', {
+        mode: 'subscription',
+        subscription: 'sub_test_error',
+        metadata: { organizationId: 'org-error' },
+      })
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      // subscriptions.retrieve でエラーを発生させる
+      mockStripe.subscriptions.retrieve.mockRejectedValue(
+        new Error('Stripe API error')
+      )
+
+      const event = createMockEvent({
+        rawBody: '{"type":"checkout.session.completed"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      await expect(handler(event)).rejects.toMatchObject({
+        statusCode: 500,
+      })
+    })
+  })
+
+  // ----------------------------------------------------------
+  // syncSubscription ヘルパーの追加テスト
+  // ----------------------------------------------------------
+  describe('syncSubscription ヘルパー', () => {
+    it('プランタイプを product metadata から検出する', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'Enterprise Plan',
+        metadata: { planType: 'ENTERPRISE' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      await handler(event)
+
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            planType: 'ENTERPRISE',
+            maxUsers: -1,
+            monthlyAiCredits: -1,
+          }),
+        })
+      )
+    })
+
+    it('product metadata にプランタイプがない場合、名前からフォールバック検出する', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'スターター',
+        metadata: {}, // planType なし
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      await handler(event)
+
+      // 名前から STARTER と判定されることを確認
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            planType: 'STARTER',
+          }),
+        })
+      )
+    })
+
+    it('Stripe ステータス mapping が正しい（trialing → TRIALING）', async () => {
+      const mockSub = createMockSubscription({ status: 'trialing' })
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'ビジネスプラン',
+        metadata: { planType: 'BUSINESS' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      await handler(event)
+
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            status: 'TRIALING',
+          }),
+        })
+      )
+    })
+
+    it('trial_end と canceled_at が正しく Date に変換される', async () => {
+      const trialEnd = 1700100000
+      const canceledAt = 1700200000
+      const mockSub = createMockSubscription({
+        trial_end: trialEnd,
+        canceled_at: canceledAt,
+      })
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: 'ビジネスプラン',
+        metadata: { planType: 'BUSINESS' },
+      })
+      mockPrisma.subscription.upsert.mockResolvedValue({})
+      mockAiCredits.initializeCredits.mockResolvedValue(undefined)
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      await handler(event)
+
+      expect(mockPrisma.subscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            trialEndsAt: new Date(trialEnd * 1000),
+            canceledAt: new Date(canceledAt * 1000),
+          }),
+        })
+      )
+    })
+
+    it('クレジットパック商品（metadata.credits あり）はサブスクリプション同期をスキップ', async () => {
+      const mockSub = createMockSubscription()
+      const stripeEvent = createStripeEvent('customer.subscription.updated', mockSub)
+
+      mockStripe.webhooks.constructEvent.mockReturnValue(stripeEvent)
+      mockStripe.products.retrieve.mockResolvedValue({
+        id: 'prod_test_123',
+        name: '100クレジットパック',
+        metadata: { credits: '100' }, // クレジットパック商品
+      })
+
+      const event = createMockEvent({
+        rawBody: '{"type":"customer.subscription.updated"}',
+        headers: { 'stripe-signature': 'sig_valid' },
+      })
+
+      const result = await handler(event)
+
+      // upsert が呼ばれないことを確認（クレジットパックはスキップ）
+      expect(mockPrisma.subscription.upsert).not.toHaveBeenCalled()
+      expect(result).toEqual({ received: true })
+    })
+  })
+})

--- a/server/api/departments/departments-crud.test.ts
+++ b/server/api/departments/departments-crud.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Departments CRUD Integration Tests
+ *
+ * テスト対象:
+ * - POST   /api/departments       (部署作成)
+ * - PATCH  /api/departments/:id   (部署更新)
+ * - DELETE /api/departments/:id   (部署削除)
+ *
+ * 全エンドポイントで ADMIN 権限必須
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ================================================================
+// モック定義（vi.hoisted で変数を事前に定義）
+// ================================================================
+
+const {
+  mockPrisma,
+  mockAuth,
+  mockRequireAdmin,
+  mockReadBody,
+  mockGetRouterParam,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    department: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+  mockAuth: vi.fn(),
+  mockRequireAdmin: vi.fn(),
+  mockReadBody: vi.fn(),
+  mockGetRouterParam: vi.fn(),
+}))
+
+// モック登録
+vi.mock('~/server/utils/prisma', () => ({ prisma: mockPrisma }))
+vi.mock('~/server/utils/authMiddleware', () => ({
+  requireAuth: mockAuth,
+  requireAdmin: mockRequireAdmin,
+}))
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<typeof import('h3')>('h3')
+  return { ...actual, readBody: mockReadBody, getRouterParam: mockGetRouterParam }
+})
+
+// ================================================================
+// ハンドラインポート
+// ================================================================
+
+import postHandler from './index.post'
+import patchHandler from './[id].patch'
+import deleteHandler from './[id].delete'
+
+// ================================================================
+// テスト用定数
+// ================================================================
+
+const DEFAULT_AUTH = {
+  organizationId: 'org-test',
+  userId: 'user-test',
+  role: 'ADMIN',
+  email: 'admin@test.com',
+}
+
+const MOCK_EVENT = {} as Parameters<typeof postHandler>[0]
+
+// ================================================================
+// Nuxt auto-import のグローバル上書き
+// getRouterParam は PATCH / DELETE で auto-import として使用される
+// ================================================================
+
+// @ts-ignore
+globalThis.getRouterParam = mockGetRouterParam
+
+// ================================================================
+// 共通セットアップ
+// ================================================================
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // デフォルト: 認証成功・ADMIN
+  mockAuth.mockResolvedValue(DEFAULT_AUTH)
+  mockRequireAdmin.mockImplementation(() => {})
+})
+
+// ================================================================
+// POST /api/departments
+// ================================================================
+
+describe('POST /api/departments', () => {
+  it('認証なし → 401', async () => {
+    mockAuth.mockRejectedValue(
+      new Error('認証が必要です')
+    )
+
+    await expect(postHandler(MOCK_EVENT)).rejects.toThrow('認証が必要です')
+  })
+
+  it('非ADMIN → 403', async () => {
+    mockAuth.mockResolvedValue({ ...DEFAULT_AUTH, role: 'MEMBER' })
+    mockRequireAdmin.mockImplementation(() => {
+      throw new Error('管理者権限が必要です')
+    })
+
+    await expect(postHandler(MOCK_EVENT)).rejects.toThrow('管理者権限が必要です')
+  })
+
+  it('名前なし → 400', async () => {
+    mockReadBody.mockResolvedValue({})
+
+    await expect(postHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
+  it('名前が空文字 → 400', async () => {
+    mockReadBody.mockResolvedValue({ name: '   ' })
+
+    await expect(postHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
+  it('重複名 → 409', async () => {
+    mockReadBody.mockResolvedValue({ name: '電気工事部' })
+    mockPrisma.department.findFirst.mockResolvedValue({
+      id: 'dept-existing',
+      name: '電気工事部',
+      organizationId: 'org-test',
+    })
+
+    await expect(postHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 409,
+    })
+
+    // organizationId スコープでの重複チェックを確認
+    expect(mockPrisma.department.findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: 'org-test',
+        name: '電気工事部',
+      },
+    })
+  })
+
+  it('正常系: 部署作成成功', async () => {
+    mockReadBody.mockResolvedValue({ name: '設備管理部', color: '#FF0000', sortOrder: 1 })
+    mockPrisma.department.findFirst.mockResolvedValue(null) // 重複なし
+    mockPrisma.department.create.mockResolvedValue({
+      id: 'dept-new',
+      name: '設備管理部',
+      color: '#FF0000',
+      sortOrder: 1,
+      organizationId: 'org-test',
+    })
+
+    const result = await postHandler(MOCK_EVENT)
+
+    expect(result).toEqual({
+      success: true,
+      department: {
+        id: 'dept-new',
+        name: '設備管理部',
+        color: '#FF0000',
+        sortOrder: 1,
+      },
+    })
+
+    // organizationId 付きで作成されていることを確認
+    expect(mockPrisma.department.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: 'org-test',
+        name: '設備管理部',
+        color: '#FF0000',
+        sortOrder: 1,
+      },
+    })
+  })
+})
+
+// ================================================================
+// PATCH /api/departments/:id
+// ================================================================
+
+describe('PATCH /api/departments/:id', () => {
+  it('認証なし → 401', async () => {
+    mockAuth.mockRejectedValue(
+      new Error('認証が必要です')
+    )
+
+    await expect(patchHandler(MOCK_EVENT)).rejects.toThrow('認証が必要です')
+  })
+
+  it('非ADMIN → 403', async () => {
+    mockAuth.mockResolvedValue({ ...DEFAULT_AUTH, role: 'MEMBER' })
+    mockRequireAdmin.mockImplementation(() => {
+      throw new Error('管理者権限が必要です')
+    })
+
+    await expect(patchHandler(MOCK_EVENT)).rejects.toThrow('管理者権限が必要です')
+  })
+
+  it('IDなし → 400', async () => {
+    mockGetRouterParam.mockReturnValue(undefined)
+
+    await expect(patchHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
+  it('存在しない部署 → 404', async () => {
+    mockGetRouterParam.mockReturnValue('dept-nonexistent')
+    mockPrisma.department.findFirst.mockResolvedValue(null)
+
+    await expect(patchHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 404,
+    })
+
+    // organizationId スコープでの検索を確認
+    expect(mockPrisma.department.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'dept-nonexistent',
+        organizationId: 'org-test',
+      },
+    })
+  })
+
+  it('重複名（別ID） → 409', async () => {
+    mockGetRouterParam.mockReturnValue('dept-1')
+    mockPrisma.department.findFirst
+      // 1回目: 存在確認 → 見つかる
+      .mockResolvedValueOnce({
+        id: 'dept-1',
+        name: '旧部署名',
+        organizationId: 'org-test',
+      })
+      // 2回目: 重複チェック → 別IDで同名が見つかる
+      .mockResolvedValueOnce({
+        id: 'dept-other',
+        name: '電気工事部',
+        organizationId: 'org-test',
+      })
+    mockReadBody.mockResolvedValue({ name: '電気工事部' })
+
+    await expect(patchHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 409,
+    })
+
+    // 重複チェックの where 句に NOT: { id } が含まれていることを確認
+    expect(mockPrisma.department.findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: 'org-test',
+        name: '電気工事部',
+        NOT: { id: 'dept-1' },
+      },
+    })
+  })
+
+  it('正常系: 部署更新成功', async () => {
+    mockGetRouterParam.mockReturnValue('dept-1')
+    mockPrisma.department.findFirst.mockResolvedValue({
+      id: 'dept-1',
+      name: '旧部署名',
+      organizationId: 'org-test',
+      color: null,
+      sortOrder: 0,
+    })
+    mockReadBody.mockResolvedValue({ name: '新部署名', color: '#00FF00' })
+    // 重複チェック → 重複なし
+    mockPrisma.department.findFirst
+      .mockResolvedValueOnce({
+        id: 'dept-1',
+        name: '旧部署名',
+        organizationId: 'org-test',
+      })
+      .mockResolvedValueOnce(null)
+    mockPrisma.department.update.mockResolvedValue({
+      id: 'dept-1',
+      name: '新部署名',
+      color: '#00FF00',
+      sortOrder: 0,
+      organizationId: 'org-test',
+    })
+
+    const result = await patchHandler(MOCK_EVENT)
+
+    expect(result).toEqual({
+      success: true,
+      department: {
+        id: 'dept-1',
+        name: '新部署名',
+        color: '#00FF00',
+        sortOrder: 0,
+      },
+    })
+
+    expect(mockPrisma.department.update).toHaveBeenCalledWith({
+      where: { id: 'dept-1' },
+      data: {
+        name: '新部署名',
+        color: '#00FF00',
+      },
+    })
+  })
+})
+
+// ================================================================
+// DELETE /api/departments/:id
+// ================================================================
+
+describe('DELETE /api/departments/:id', () => {
+  it('認証なし → 401', async () => {
+    mockAuth.mockRejectedValue(
+      new Error('認証が必要です')
+    )
+
+    await expect(deleteHandler(MOCK_EVENT)).rejects.toThrow('認証が必要です')
+  })
+
+  it('非ADMIN → 403', async () => {
+    mockAuth.mockResolvedValue({ ...DEFAULT_AUTH, role: 'MEMBER' })
+    mockRequireAdmin.mockImplementation(() => {
+      throw new Error('管理者権限が必要です')
+    })
+
+    await expect(deleteHandler(MOCK_EVENT)).rejects.toThrow('管理者権限が必要です')
+  })
+
+  it('IDなし → 400', async () => {
+    mockGetRouterParam.mockReturnValue(undefined)
+
+    await expect(deleteHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
+  it('存在しない部署 → 404', async () => {
+    mockGetRouterParam.mockReturnValue('dept-nonexistent')
+    mockPrisma.department.findFirst.mockResolvedValue(null)
+
+    await expect(deleteHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 404,
+    })
+
+    // deletedAt: null を含む検索でソフトデリート済みを除外していることを確認
+    expect(mockPrisma.department.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'dept-nonexistent',
+        organizationId: 'org-test',
+        deletedAt: null,
+      },
+      include: {
+        _count: {
+          select: { users: { where: { deletedAt: null } } },
+        },
+      },
+    })
+  })
+
+  it('所属ユーザーあり → 409', async () => {
+    mockGetRouterParam.mockReturnValue('dept-1')
+    mockPrisma.department.findFirst.mockResolvedValue({
+      id: 'dept-1',
+      name: '電気工事部',
+      organizationId: 'org-test',
+      deletedAt: null,
+      _count: { users: 3 },
+    })
+
+    await expect(deleteHandler(MOCK_EVENT)).rejects.toMatchObject({
+      statusCode: 409,
+    })
+  })
+
+  it('正常系: ソフトデリート成功', async () => {
+    mockGetRouterParam.mockReturnValue('dept-1')
+    mockPrisma.department.findFirst.mockResolvedValue({
+      id: 'dept-1',
+      name: '電気工事部',
+      organizationId: 'org-test',
+      deletedAt: null,
+      _count: { users: 0 },
+    })
+    mockPrisma.department.update.mockResolvedValue({
+      id: 'dept-1',
+      name: '電気工事部',
+      deletedAt: new Date(),
+    })
+
+    const result = await deleteHandler(MOCK_EVENT)
+
+    expect(result).toEqual({
+      success: true,
+      message: '部署を削除しました',
+    })
+
+    // ソフトデリート（deletedAt 設定）を確認
+    expect(mockPrisma.department.update).toHaveBeenCalledWith({
+      where: { id: 'dept-1' },
+      data: { deletedAt: expect.any(Date) },
+    })
+  })
+})

--- a/server/api/schedules/weekly-board.get.ts
+++ b/server/api/schedules/weekly-board.get.ts
@@ -208,11 +208,11 @@ export default defineEventHandler(async (event): Promise<WeeklyBoardResponse> =>
       organizationId: authContext.organizationId
     }
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     log.error('Failed to fetch weekly board', { error: error instanceof Error ? error : new Error(String(error)) })
 
     // 認証エラーの場合はそのまま返す
-    if (error.statusCode) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateString,
+  validateEmail,
+  validateNumber,
+  validateUUID,
+  validateDateTime,
+  validateDateRange,
+} from './validation'
+
+// Helper: assert H3Error with statusCode 400
+function expectH3Error400(fn: () => unknown, messageSubstring?: string) {
+  try {
+    fn()
+    expect.fail('Expected an error to be thrown')
+  } catch (error: unknown) {
+    const e = error as { statusCode?: number; statusMessage?: string }
+    expect(e.statusCode).toBe(400)
+    if (messageSubstring) {
+      expect(e.statusMessage).toContain(messageSubstring)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateString
+// ---------------------------------------------------------------------------
+describe('validateString', () => {
+  it('null を渡すと required=false の場合 null を返す', () => {
+    expect(validateString(null, 'テスト')).toBeNull()
+  })
+
+  it('undefined を渡すと required=false の場合 null を返す', () => {
+    expect(validateString(undefined, 'テスト')).toBeNull()
+  })
+
+  it('空文字を渡すと required=false の場合 null を返す', () => {
+    expect(validateString('', 'テスト')).toBeNull()
+  })
+
+  it('null を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString(null, '名前', { required: true }),
+      '名前は必須です'
+    )
+  })
+
+  it('undefined を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString(undefined, '名前', { required: true }),
+      '名前は必須です'
+    )
+  })
+
+  it('空文字を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString('', '名前', { required: true }),
+      '名前は必須です'
+    )
+  })
+
+  it('文字列でない値を渡すと 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString(123, 'フィールド'),
+      'フィールドは文字列で指定してください'
+    )
+  })
+
+  it('スペースのみの文字列で required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString('   ', '名前', { required: true }),
+      '名前は必須です'
+    )
+  })
+
+  it('minLength 未満の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString('ab', 'パスワード', { minLength: 3 }),
+      'パスワードは3文字以上で入力してください'
+    )
+  })
+
+  it('maxLength 超過の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString('abcdef', '名前', { maxLength: 5 }),
+      '名前は5文字以内で入力してください'
+    )
+  })
+
+  it('pattern に一致しない場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateString('abc', 'コード', { pattern: /^[0-9]+$/ }),
+      'コードの形式が不正です'
+    )
+  })
+
+  it('pattern 不一致時にカスタム patternMessage を使用する', () => {
+    expectH3Error400(
+      () =>
+        validateString('abc', 'コード', {
+          pattern: /^[0-9]+$/,
+          patternMessage: '数字のみ入力可能です',
+        }),
+      '数字のみ入力可能です'
+    )
+  })
+
+  it('有効な文字列を渡すとトリムして返す', () => {
+    expect(validateString('  hello  ', 'テスト')).toBe('hello')
+  })
+
+  it('有効な文字列で required=true の場合もトリムして返す', () => {
+    expect(validateString(' world ', 'テスト', { required: true })).toBe('world')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateEmail
+// ---------------------------------------------------------------------------
+describe('validateEmail', () => {
+  it('null を渡すと 400 エラーを投げる（必須）', () => {
+    expectH3Error400(
+      () => validateEmail(null),
+      'メールアドレスは必須です'
+    )
+  })
+
+  it('空文字を渡すと 400 エラーを投げる（必須）', () => {
+    expectH3Error400(
+      () => validateEmail(''),
+      'メールアドレスは必須です'
+    )
+  })
+
+  it('不正なメール形式の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateEmail('not-an-email'),
+      'メールアドレスの形式が不正です'
+    )
+  })
+
+  it('@ のみの場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateEmail('@'),
+      'メールアドレスの形式が不正です'
+    )
+  })
+
+  it('有効なメールアドレスを小文字トリムして返す', () => {
+    expect(validateEmail('  User@Example.COM  ')).toBe('user@example.com')
+  })
+
+  it('254文字を超えるメールアドレスは 400 エラーを投げる', () => {
+    const longLocal = 'a'.repeat(243) // 243 + @ + example.com(10) = 254 超
+    const longEmail = `${longLocal}@example.com`
+    // 255 chars total
+    expectH3Error400(
+      () => validateEmail(longEmail),
+      '254文字以内で入力してください'
+    )
+  })
+
+  it('カスタム fieldName を使用できる', () => {
+    expectH3Error400(
+      () => validateEmail(null, '連絡先メール'),
+      '連絡先メールは必須です'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateNumber
+// ---------------------------------------------------------------------------
+describe('validateNumber', () => {
+  it('null を渡すと required=false の場合 null を返す', () => {
+    expect(validateNumber(null, '数量')).toBeNull()
+  })
+
+  it('undefined を渡すと required=false の場合 null を返す', () => {
+    expect(validateNumber(undefined, '数量')).toBeNull()
+  })
+
+  it('空文字を渡すと required=false の場合 null を返す', () => {
+    expect(validateNumber('', '数量')).toBeNull()
+  })
+
+  it('null を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber(null, '数量', { required: true }),
+      '数量は必須です'
+    )
+  })
+
+  it('undefined を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber(undefined, '数量', { required: true }),
+      '数量は必須です'
+    )
+  })
+
+  it('NaN になる値を渡すと 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber('abc', '数量'),
+      '数量は数値で指定してください'
+    )
+  })
+
+  it('integer=true で小数値を渡すと 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber(3.14, '個数', { integer: true }),
+      '個数は整数で指定してください'
+    )
+  })
+
+  it('min 未満の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber(0, '年齢', { min: 1 }),
+      '年齢は1以上で指定してください'
+    )
+  })
+
+  it('max 超過の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateNumber(200, '年齢', { max: 150 }),
+      '年齢は150以下で指定してください'
+    )
+  })
+
+  it('文字列 "42" を渡すと数値 42 に変換して返す', () => {
+    expect(validateNumber('42', '数量')).toBe(42)
+  })
+
+  it('有効な数値をそのまま返す', () => {
+    expect(validateNumber(99, '数量')).toBe(99)
+  })
+
+  it('integer=true で整数値を渡すと正常に返す', () => {
+    expect(validateNumber(10, '個数', { integer: true })).toBe(10)
+  })
+
+  it('min と max の範囲内の値を正常に返す', () => {
+    expect(validateNumber(50, '年齢', { min: 0, max: 150 })).toBe(50)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateUUID
+// ---------------------------------------------------------------------------
+describe('validateUUID', () => {
+  it('null を渡すと 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateUUID(null, 'ID'),
+      'IDは必須です'
+    )
+  })
+
+  it('空文字を渡すと 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateUUID('', 'ID'),
+      'IDは必須です'
+    )
+  })
+
+  it('不正な UUID 形式の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateUUID('not-a-uuid', 'プロジェクトID'),
+      'プロジェクトIDのID形式が不正です'
+    )
+  })
+
+  it('ハイフンなしの UUID は 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateUUID('550e8400e29b41d4a716446655440000', 'ID'),
+      'IDのID形式が不正です'
+    )
+  })
+
+  it('有効な UUID を正常に返す', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    expect(validateUUID(uuid, 'ID')).toBe(uuid)
+  })
+
+  it('大文字の UUID も正常に返す', () => {
+    const uuid = '550E8400-E29B-41D4-A716-446655440000'
+    expect(validateUUID(uuid, 'ID')).toBe(uuid)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateDateTime
+// ---------------------------------------------------------------------------
+describe('validateDateTime', () => {
+  it('null を渡すと required=false の場合 null を返す', () => {
+    expect(validateDateTime(null, '日時')).toBeNull()
+  })
+
+  it('undefined を渡すと required=false の場合 null を返す', () => {
+    expect(validateDateTime(undefined, '日時')).toBeNull()
+  })
+
+  it('空文字を渡すと required=false の場合 null を返す', () => {
+    expect(validateDateTime('', '日時')).toBeNull()
+  })
+
+  it('null を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateDateTime(null, '開始日時', { required: true }),
+      '開始日時は必須です'
+    )
+  })
+
+  it('空文字を渡すと required=true の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateDateTime('', '開始日時', { required: true }),
+      '開始日時は必須です'
+    )
+  })
+
+  it('不正な日時文字列の場合 400 エラーを投げる', () => {
+    expectH3Error400(
+      () => validateDateTime('not-a-date', '日時'),
+      '日時の日時形式が不正です'
+    )
+  })
+
+  it('有効な ISO 文字列を Date オブジェクトで返す', () => {
+    const result = validateDateTime('2025-01-15T09:00:00.000Z', '日時')
+    expect(result).toBeInstanceOf(Date)
+    expect(result!.toISOString()).toBe('2025-01-15T09:00:00.000Z')
+  })
+
+  it('有効な日付文字列を Date オブジェクトで返す', () => {
+    const result = validateDateTime('2025-06-01', '日時')
+    expect(result).toBeInstanceOf(Date)
+    expect(result!.getFullYear()).toBe(2025)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateDateRange
+// ---------------------------------------------------------------------------
+describe('validateDateRange', () => {
+  it('start >= end の場合 400 エラーを投げる（同一日時）', () => {
+    const date = new Date('2025-01-15T09:00:00.000Z')
+    expectH3Error400(
+      () => validateDateRange(date, date),
+      '開始日時は終了日時より前である必要があります'
+    )
+  })
+
+  it('start > end の場合 400 エラーを投げる', () => {
+    const start = new Date('2025-01-16T09:00:00.000Z')
+    const end = new Date('2025-01-15T09:00:00.000Z')
+    expectH3Error400(
+      () => validateDateRange(start, end),
+      '開始日時は終了日時より前である必要があります'
+    )
+  })
+
+  it('カスタム名でエラーメッセージを表示する', () => {
+    const start = new Date('2025-01-16T09:00:00.000Z')
+    const end = new Date('2025-01-15T09:00:00.000Z')
+    expectH3Error400(
+      () => validateDateRange(start, end, '着工日', '竣工日'),
+      '着工日は竣工日より前である必要があります'
+    )
+  })
+
+  it('start < end の場合エラーを投げない', () => {
+    const start = new Date('2025-01-15T09:00:00.000Z')
+    const end = new Date('2025-01-16T09:00:00.000Z')
+    expect(() => validateDateRange(start, end)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- **テスト+143**: 438 → 581テスト（33%増）、カバレッジギャップを大幅に埋めた
- **Stripe Webhook テスト**: 金銭に関わる最重要コードに27テスト追加（全イベントタイプ網羅）
- **Admin API テスト**: 未テストだった管理者API 6エンドポイントに28テスト追加
- **OTP認証テスト**: 未テストだったOTP 2FA フロー 3エンドポイントに18テスト追加
- **departments CRUDテスト**: POST/PATCH/DELETE の18テスト追加
- **validation.tsテスト**: バリデーションユーティリティに52テスト追加
- **型安全性**: `catch (error: any)` → `catch (error: unknown)` に本番コード10箇所修正
- **Stale PR 9件クローズ**: 2025年5月の旧JSスタック向けPRを整理

## New Test Files
| ファイル | テスト数 | カバー対象 |
|---------|---------|-----------|
| billing/webhook.test.ts | 27 | Stripe全Webhookイベント |
| admin/admin.test.ts | 28 | audit-logs, dashboard, backups, llm-settings |
| auth/otp/otp.test.ts | 18 | OTP send/verify/status |
| departments-crud.test.ts | 18 | POST/PATCH/DELETE |
| validation.test.ts | 52 | validateString/Email/Number/UUID/DateTime/DateRange |

## Test plan
- [x] `npm run typecheck` - エラーなし
- [x] `npm run test` - 52ファイル / 581テスト全通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)