### PR TITLE
fix: 全画面のログアウト・POST操作にCSRFトークンを追加

### DIFF
--- a/components/admin/AdminNav.vue
+++ b/components/admin/AdminNav.vue
@@ -25,9 +25,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useCsrf } from '~/composables/useCsrf'
 
 const route = useRoute()
 const router = useRouter()
+const { csrfFetch } = useCsrf()
 const userName = ref('')
 
 function isActive(path: string): boolean {
@@ -36,7 +38,7 @@ function isActive(path: string): boolean {
 
 async function logout() {
   try {
-    await $fetch('/api/auth/logout', { method: 'POST' })
+    await csrfFetch('/api/auth/logout', { method: 'POST' })
   } catch {
     // ignore
   }

--- a/components/billing/OtpVerifyModal.vue
+++ b/components/billing/OtpVerifyModal.vue
@@ -51,6 +51,10 @@
 </template>
 
 <script setup lang="ts">
+import { useCsrf } from '~/composables/useCsrf'
+
+const { csrfFetch } = useCsrf()
+
 const props = defineProps<{
   visible: boolean
 }>()
@@ -83,7 +87,7 @@ async function sendCode() {
   sending.value = true
   errorMsg.value = ''
   try {
-    await $fetch('/api/auth/otp/send', { method: 'POST' })
+    await csrfFetch('/api/auth/otp/send', { method: 'POST' })
     step.value = 'verify'
     startCooldown()
     nextTick(() => codeInput.value?.focus())

--- a/components/common/AppHeader.vue
+++ b/components/common/AppHeader.vue
@@ -229,10 +229,12 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
+import { useCsrf } from '~/composables/useCsrf'
 
 const route = useRoute()
 const router = useRouter()
 const { user: authUser, isAuthenticated, fetchMe } = useAuth()
+const { csrfFetch } = useCsrf()
 
 // Product menu
 const productMenuOpen = ref(false)
@@ -336,7 +338,7 @@ function handleClickOutside(event: MouseEvent) {
 async function handleLogout() {
   closeMenu()
   try {
-    await $fetch('/api/auth/logout', { method: 'POST' })
+    await csrfFetch('/api/auth/logout', { method: 'POST' })
   } catch {
     // ignore
   }
@@ -348,7 +350,7 @@ async function handleLogout() {
 async function handleMobileLogout() {
   closeMobileMenu()
   try {
-    await $fetch('/api/auth/logout', { method: 'POST' })
+    await csrfFetch('/api/auth/logout', { method: 'POST' })
   } catch {
     // ignore
   }

--- a/layouts/platform.vue
+++ b/layouts/platform.vue
@@ -88,9 +88,11 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useCsrf } from '~/composables/useCsrf'
 
 const route = useRoute()
 const router = useRouter()
+const { csrfFetch } = useCsrf()
 
 const { data: authData } = await useFetch('/api/auth/me')
 const user = computed(() => authData.value?.user)
@@ -112,7 +114,7 @@ function closeSidebar() {
 }
 
 async function logout() {
-  await $fetch('/api/auth/logout', { method: 'POST' })
+  await csrfFetch('/api/auth/logout', { method: 'POST' })
   router.push('/login')
 }
 

--- a/pages/admin/departments.vue
+++ b/pages/admin/departments.vue
@@ -71,6 +71,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useCsrf } from '~/composables/useCsrf'
 definePageMeta({
   middleware: 'admin'
 })
@@ -82,6 +83,8 @@ interface Department {
   sortOrder: number
   userCount: number
 }
+
+const { csrfFetch } = useCsrf()
 
 const departments = ref<Department[]>([])
 const loading = ref(true)
@@ -174,7 +177,7 @@ async function deleteDepartment(dept: Department) {
   }
 
   try {
-    await $fetch(`/api/departments/${dept.id}`, { method: 'DELETE' })
+    await csrfFetch(`/api/departments/${dept.id}`, { method: 'DELETE' })
     await fetchDepartments()
   } catch (error: unknown) {
     const errData = error && typeof error === 'object' && 'data' in error ? (error as Record<string, unknown>).data as Record<string, unknown> | undefined : undefined


### PR DESCRIPTION
## Summary
- 全画面で `$fetch` → `csrfFetch` に置換し、CSRFトークン未送信エラーを解消
- プラットフォーム管理画面・通常画面・管理画面・OTP・部署削除の5箇所を修正

## 修正箇所
| ファイル | 操作 |
|---------|------|
| `layouts/platform.vue` | ログアウト |
| `components/common/AppHeader.vue` | ログアウト×2（デスクトップ/モバイル） |
| `components/admin/AdminNav.vue` | ログアウト |
| `components/billing/OtpVerifyModal.vue` | OTP送信 |
| `pages/admin/departments.vue` | 部署削除 |

## Test plan
- [x] `npm run typecheck` — 0エラー
- [x] `npm run test` — 687テスト全通過
- [ ] プラットフォーム管理画面でログアウトできることを確認
- [ ] 通常画面でログアウトできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)