### PR TITLE
chore: mark NOTIF-001 as done (already implemented)

### DIFF
--- a/.framework/plan.json
+++ b/.framework/plan.json
@@ -25,7 +25,9 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 1,
           "status": "done"
         },
@@ -35,7 +37,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -45,7 +49,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 1,
           "status": "done"
         },
@@ -55,7 +61,9 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 1,
           "status": "done"
         },
@@ -65,7 +73,10 @@
           "priority": "P1",
           "size": "M",
           "type": "common",
-          "dependencies": ["AUTH-001", "AUTH-007"],
+          "dependencies": [
+            "AUTH-001",
+            "AUTH-007"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -75,7 +86,9 @@
           "priority": "P1",
           "size": "S",
           "type": "common",
-          "dependencies": ["AUTH-009"],
+          "dependencies": [
+            "AUTH-009"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -85,7 +98,9 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 2,
           "status": "done"
         },
@@ -95,7 +110,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["ACCT-001"],
+          "dependencies": [
+            "ACCT-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -105,7 +122,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["ACCT-001"],
+          "dependencies": [
+            "ACCT-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -115,7 +134,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["AUTH-001"],
+          "dependencies": [
+            "AUTH-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         }
@@ -143,7 +164,9 @@
           "priority": "P0",
           "size": "L",
           "type": "common",
-          "dependencies": ["ROLE-001"],
+          "dependencies": [
+            "ROLE-001"
+          ],
           "dependencyCount": 2,
           "status": "done"
         },
@@ -153,7 +176,9 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["ROLE-002"],
+          "dependencies": [
+            "ROLE-002"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -163,7 +188,9 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["ROLE-002"],
+          "dependencies": [
+            "ROLE-002"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -173,7 +200,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["ROLE-001"],
+          "dependencies": [
+            "ROLE-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -193,7 +222,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["NAV-001"],
+          "dependencies": [
+            "NAV-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -203,7 +234,10 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["NAV-001", "ROLE-002"],
+          "dependencies": [
+            "NAV-001",
+            "ROLE-002"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -213,7 +247,9 @@
           "priority": "P1",
           "size": "M",
           "type": "common",
-          "dependencies": ["NAV-001"],
+          "dependencies": [
+            "NAV-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -293,7 +329,9 @@
           "priority": "P0",
           "size": "S",
           "type": "common",
-          "dependencies": ["ROLE-002"],
+          "dependencies": [
+            "ROLE-002"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -393,7 +431,9 @@
           "priority": "P0",
           "size": "L",
           "type": "common",
-          "dependencies": ["ROLE-002"],
+          "dependencies": [
+            "ROLE-002"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -403,7 +443,10 @@
           "priority": "P0",
           "size": "M",
           "type": "common",
-          "dependencies": ["ACCT-001", "ROLE-001"],
+          "dependencies": [
+            "ACCT-001",
+            "ROLE-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -440,7 +483,12 @@
           "priority": "P0",
           "size": "XL",
           "type": "proprietary",
-          "dependencies": ["CRUD-001", "CRUD-002", "LIST-003", "LIST-004"],
+          "dependencies": [
+            "CRUD-001",
+            "CRUD-002",
+            "LIST-003",
+            "LIST-004"
+          ],
           "dependencyCount": 2,
           "status": "done"
         },
@@ -450,7 +498,9 @@
           "priority": "P0",
           "size": "L",
           "type": "proprietary",
-          "dependencies": ["WBS-001"],
+          "dependencies": [
+            "WBS-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -470,7 +520,9 @@
           "priority": "P0",
           "size": "M",
           "type": "proprietary",
-          "dependencies": ["NAV-001"],
+          "dependencies": [
+            "NAV-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -480,7 +532,9 @@
           "priority": "P0",
           "size": "M",
           "type": "proprietary",
-          "dependencies": ["NAV-001"],
+          "dependencies": [
+            "NAV-001"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -507,7 +561,9 @@
           "priority": "P0",
           "size": "XL",
           "type": "proprietary",
-          "dependencies": ["WBS-001"],
+          "dependencies": [
+            "WBS-001"
+          ],
           "dependencyCount": 1,
           "status": "done"
         },
@@ -517,7 +573,10 @@
           "priority": "P1",
           "size": "L",
           "type": "proprietary",
-          "dependencies": ["WBS-001", "WBS-003"],
+          "dependencies": [
+            "WBS-001",
+            "WBS-003"
+          ],
           "dependencyCount": 0,
           "status": "done"
         },
@@ -527,7 +586,9 @@
           "priority": "P1",
           "size": "L",
           "type": "proprietary",
-          "dependencies": ["WBS-004"],
+          "dependencies": [
+            "WBS-004"
+          ],
           "dependencyCount": 0,
           "status": "done"
         }
@@ -546,7 +607,7 @@
           "type": "proprietary",
           "dependencies": [],
           "dependencyCount": 0,
-          "status": "backlog"
+          "status": "done"
         }
       ]
     }


### PR DESCRIPTION
NOTIF-001（メール通知）は既にコミット#408で実装済みでしたが、plan.jsonの更新が漏れていました。

## 確認内容
- `server/utils/email.ts`: Resend実装済み
- `server/utils/notificationTemplates.ts`: テンプレート実装済み  
- `tests/notification.test.ts`: テスト実装済み

## 変更
- plan.json で NOTIF-001 の status を "backlog" → "done" に更新

これで全51機能が完了しました 🎉