### PR TITLE
fix(tests): Set DATABASE_URL in test environment

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,6 +7,11 @@
 import { vi } from 'vitest'
 import * as h3 from 'h3'
 
+// Set DATABASE_URL for tests if not already set
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = 'postgresql://wbs_dev:wbs_dev_password@localhost:5432/wbs_test'
+}
+
 // Nuxt auto-imports をグローバルに定義
 // @ts-ignore
 globalThis.defineEventHandler = h3.defineEventHandler


### PR DESCRIPTION
## Summary
Fixed 26 failing test files by setting DATABASE_URL in test setup.

## Changes
- Updated tests/setup.ts to set DATABASE_URL for PostgreSQL
- All 717 tests now passing

## Testing
✅ All tests pass locally
✅ CI expected to pass