### PR TITLE
fix: /admin 直リンク404を修正

### DIFF
--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+/**
+ * /admin のインデックスページ
+ * /admin/users へリダイレクトする
+ */
+definePageMeta({
+  middleware: 'admin'
+})
+
+await navigateTo('/admin/users', { replace: true })
+</script>


### PR DESCRIPTION
## Summary
- `/admin` への直リンクアクセスで404になる問題を修正
- `pages/admin/index.vue` を追加し、`/admin/users` へリダイレクトするよう設定
- Nuxt 3のファイルベースルーティングでindex.vueが存在しなかったことが原因

## Test plan
- [ ] `https://mieruplus.jp/admin` に直リンクアクセスして `/admin/users` にリダイレクトされることを確認
- [ ] admin middlewareが正常に動作し、未認証ユーザーは `/login` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)