### PR TITLE
fix: Material Symbolsアイコンが文字表示される問題を修正

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -10,7 +10,13 @@ useHead({
   titleTemplate: '%s | ミエルボード for 現場',
   htmlAttrs: {
     lang: 'ja'
-  }
+  },
+  link: [
+    {
+      rel: 'stylesheet',
+      href: 'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'
+    }
+  ]
 })
 </script>
 


### PR DESCRIPTION
## Summary
- `layouts/platform.vue` で使用している Material Symbols Outlined フォントのCDN読み込みが未設定だった
- `app.vue` の `useHead` に Google Fonts CDN リンクを追加
- これにより `dashboard`, `layers`, `bolt` 等のアイコンが正しく表示される

## Test plan
- [ ] https://mieruplus.jp/platform にログインしてサイドバーのアイコンが正しく表示されることを確認
- [ ] アイコンがテキスト（`dashboard` 等）ではなくグラフィカルに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)